### PR TITLE
build_all.sh updates

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -1,22 +1,23 @@
 #!/bin/bash
 
 function build () {
-        local service=$1
-        echo "##### $service ####"
-		cd $service
-		if [ -e build.sh ]; then
-            echo "##### -> ./build.sh"
-			sh build.sh
-		elif [ -e Dockerfile ]; then
-            echo "##### -> docker build -t raintank/$service ."
-			docker build -t raintank/$service .
-		fi
-		STATE=$?
-		if [ $STATE -ne 0 ]; then
-		  echo "failed building $service. stopping." >&2
-		  exit $STATE;
-		fi 
-		cd ..
+	local service=$1
+	cd $service
+	[ -e build.sh -o -e Dockerfile ] || continue
+	echo "##### $service ####"
+	if [ -e build.sh ]; then
+		echo "##### -> ./build.sh"
+		sh build.sh
+	elif [ -e Dockerfile ]; then
+		echo "##### -> docker build -t raintank/$service ."
+		docker build -t raintank/$service .
+	fi
+	STATE=$?
+	if [ $STATE -ne 0 ]; then
+		echo "failed building $service. stopping." >&2
+		exit $STATE;
+	fi
+	cd ..
 }
 
 # first build containers on which others depend
@@ -26,4 +27,4 @@ build nodejs
 for i in *; do
 	[ -d $i ] && [[ $i != nodejs ]] && build $i
 done
-
+exit 0


### PR DESCRIPTION
- fix indentation
- skip directories that don't have build.sh or Dockerfile
  (such as raintank_code dir)
- always exit 0 if everything went ok, instead of using whatever
  the exit code of whatever the bash test expressions happpened to be
