### PR TITLE
enable running arbitrary amount of collectors. fix #17

### DIFF
--- a/launch_dev.sh
+++ b/launch_dev.sh
@@ -33,9 +33,6 @@ screen -S raintank -X screen -t grafana docker exec -t -i raintankdocker_grafana
 #raintank-metric - this app consumes the metric data written to the message queue and sends it to influxdb.  The app also performs threshold checking and data roll-ups
 screen -S raintank -X screen -t metric docker exec -t -i raintankdocker_raintankMetric_1 bash
 
-#raintank-collector - this is an instance of an edge collector.
-screen -S raintank -X screen -t collector docker exec -t -i raintankdocker_raintankCollector_1 bash
-
 # open a mysql cli for convenience
 screen -S raintank -X screen -t mysql-cli docker exec -t -i $(docker ps | awk '/raintankdocker_mysql_1/ {print $1}') mysql -prootpass grafana
 
@@ -43,6 +40,9 @@ sleep 5
 screen -S raintank -p graphite-api -X stuff 'tail -10f /var/log/raintank/graphite-api.log\n'
 screen -S raintank -p grafana -X stuff 'supervisorctl restart all; tail -10f /var/log/raintank/grafana.log\n'
 screen -S raintank -p metric -X stuff 'tail -10f /var/log/raintank/metric.log\n'
-screen -S raintank -p collector -X stuff 'supervisorctl restart all; tail -10f /var/log/raintank/collector.log\n'
+
+#raintank-collector - this is an instance of an edge collector.
+./launch_dev_collector.sh dev-1
+
 
 screen -r

--- a/launch_dev_collector.sh
+++ b/launch_dev_collector.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# launch a collector with the given identifier (or a randomly generated one), and hook it into the screen session
+
+id=$1
+[ -n "$id" ] || id=$(mktemp -u XXXXXXXXXXX)
+docker_name=raintankdocker_raintankMetric_$id
+
+eval $(grep ^RT_CODE setup_dev.sh)
+
+docker run --link=raintankdocker_grafana_1:grafana \
+           -v $RT_CODE:/opt/raintank/raintank-collector \
+           -e RAINTANK_collector_name=$id -d \
+           --name=$docker_name \
+           raintank/collector
+
+screen -S raintank -X screen -t collector-$id docker exec -t -i raintankdocker_raintankCollector_1 bash
+screen -S raintank -p collector-$id -X stuff 'supervisorctl restart all; tail -10f /var/log/raintank/collector.log\n'

--- a/stop_dev.sh
+++ b/stop_dev.sh
@@ -3,4 +3,11 @@
 screen -X -S raintank quit
 docker-compose -f fig-dev.yaml stop
 yes | docker-compose -f fig-dev.yaml rm
+
+# stop other collectors that were stopped, if any
+for id in $(docker ps | grep raintankdocker_raintankMetric | cut -d' ' -f1); do
+  docker stop $id
+  docker rm $id
+done
+
 echo "Stopped docker dev environment"


### PR DESCRIPTION
by default, starts 1 collector with id dev-1, similar to before
but using ./launch_dev_collector.sh you can run many more

curious what @woodsaj thinks.. but works for me. tried both singular and several collectors :)
