### PR TITLE
WIP: use graphite for monitoring timeseries, not influxdb

### DIFF
--- a/fig-dev.yaml
+++ b/fig-dev.yaml
@@ -108,7 +108,7 @@ influxdb:
     - /opt/influxdb/shared/data
 
 graphitemon:
-  image:  hopsoft/graphite-statsd
+  image:  raintank/graphite
   hostname: graphitemon
   ports:
     - "2003:2003"

--- a/fig-dev.yaml
+++ b/fig-dev.yaml
@@ -44,7 +44,7 @@ graphiteWatcher:
   hostname: watcher
   links:
     - elasticsearch:elasticsearch
-    - influxdb:influxdb
+    - graphitemon:graphitemon
     - graphiteApi:graphite-api
   volumes:
     - ./logs:/var/log/raintank
@@ -58,7 +58,6 @@ metricTank:
   links:
     - nsqd:nsqd
     - statsdaemon:statsdaemon
-    - influxdb:influxdb
     - cassandra:cassandra
   volumes:
     - ./logs:/var/log/raintank
@@ -105,9 +104,15 @@ influxdb:
   ports:
     - "8086:8086"
     - "8083:8083"
-    - "2003:2003"
   volumes:
     - /opt/influxdb/shared/data
+
+graphitemon:
+  image:  hopsoft/graphite-statsd
+  hostname: graphitemon
+  ports:
+    - "2003:2003"
+    - "8000:80"
 
 cassandra:
   image: cassandra:2.1.9
@@ -138,7 +143,6 @@ graphiteApi:
   links:
     - elasticsearch:elasticsearch
     - statsdaemon:statsdaemon
-    - influxdb:influxdb
     - cassandra:cassandra
     - metricTank:nsqmetricstank
   environment:
@@ -172,7 +176,7 @@ statsdaemon:
   ports:
     - "8126:8126"
   links:
-    - influxdb:influxdb
+          - graphitemon:graphitemon
 
 benchmark:
   image: raintank/benchmark

--- a/grafana-dev/Dockerfile
+++ b/grafana-dev/Dockerfile
@@ -3,8 +3,8 @@ FROM raintank/grafana
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # add script, but don't run it yet. will be run when grafana is running
-ADD create-influxdb-dev-datasource.sh /tmp/create-influxdb-dev-datasource.sh
-RUN chmod +x /tmp/create-influxdb-dev-datasource.sh
+ADD create-dev-datasource.sh /tmp/create-dev-datasource.sh
+RUN chmod +x /tmp/create-dev-datasource.sh
 
 ADD prepare-nsqd.sh /tmp/prepare-nsqd.sh
 RUN chmod +x /tmp/prepare-nsqd.sh

--- a/grafana-dev/create-dev-datasource.sh
+++ b/grafana-dev/create-dev-datasource.sh
@@ -13,7 +13,11 @@ echo 'INSERT INTO api_key (`org_id`,`name`,`key`,`role`,`is_admin`,`created`,`up
 echo 'api keys currently known:'
 echo 'select * from api_key;' | mysql -prootpass grafana -h mysql
 
-echo "> adding datasource"
+echo "> adding datasources"
+
+curl -H "Authorization: Bearer eyJrIjoiMEVUVE52c3ZITnhpVldyOTI5cVFQcUxQWGR6V213bUIiLCJuIjoiZGV2c3RhY2stYWRtaW4iLCJpZCI6MX0=" \
+  -H "content-type: application/json" \
+  'http://localhost/api/datasources' -X POST --data-binary '{"name":"graphite","type":"graphite","url":"http://localhost:8000","access":"direct","isDefault":false}'
 
 curl -H "Authorization: Bearer eyJrIjoiMEVUVE52c3ZITnhpVldyOTI5cVFQcUxQWGR6V213bUIiLCJuIjoiZGV2c3RhY2stYWRtaW4iLCJpZCI6MX0=" \
   -H "content-type: application/json" \
@@ -25,3 +29,4 @@ for file in /tmp/dashboards/*; do
     -H "content-type: application/json" \
     'http://localhost/api/dashboards/db' -X POST -d "{\"dashboard\": $(cat $file)}"
 done
+

--- a/grafana-dev/dashboards/alerting.json
+++ b/grafana-dev/dashboards/alerting.json
@@ -21,7 +21,7 @@
             "tickqueue size": "#EF843C"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -61,31 +61,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "tickqueue items",
-              "column": "value",
-              "function": "mean",
-              "query": "select mean(value) from \"stats.timers.grafana.dev.alert-tickqueue.items.mean\" where $timeFilter group by time($interval) order asc",
-              "series": "stats.timers.grafana.dev.alert-tickqueue.items.mean",
-              "target": ""
+              "target": "alias(stats.timers.grafana.dev.alert-tickqueue.items.mean, 'tickqueue items')"
             },
             {
-              "alias": "tickqueue size",
-              "column": "value",
-              "function": "mean",
-              "query": "select mean(value) from \"stats.gauges.grafana.dev.alert-tickqueue.size\" where $timeFilter group by time($interval) order asc",
-              "series": "stats.gauges.grafana.dev.alert-tickqueue.size",
-              "target": ""
+              "target": "alias(stats.gauges.grafana.dev.alert-tickqueue.size, 'tickqueue size')"
             },
             {
-              "alias": "skipped",
-              "column": "value",
-              "fill": "0",
-              "function": "mean",
-              "hide": false,
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.grafana.dev.alert-dispatcher.ticks-skipped-due-to-slow-tickqueue\" where $timeFilter group by time($interval) fill(0) order asc",
-              "series": "stats.grafana.dev.alert-dispatcher.ticks-skipped-due-to-slow-tickqueue",
-              "target": ""
+              "target": "alias(stats.grafana.dev.alert-dispatcher.ticks-skipped-due-to-slow-tickqueue, 'skipped')"
             }
           ],
           "timeFrom": null,
@@ -126,7 +108,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -166,13 +148,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "column": "value",
-              "fill": "0",
-              "function": "mean",
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.grafana.dev.alert-dispatcher.num-getschedules\" where $timeFilter group by time($interval) fill(0) order asc",
-              "series": "stats.grafana.dev.alert-dispatcher.num-getschedules",
-              "target": ""
+              "target": "stats.grafana.dev.alert-dispatcher.num-getschedules"
             }
           ],
           "timeFrom": null,
@@ -193,7 +169,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -233,20 +209,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "median",
-              "column": "value",
-              "function": "mean",
-              "query": "select mean(value) from \"stats.timers.grafana.dev.alert-dispatcher.get-schedules.median\" where $timeFilter group by time($interval) order asc",
-              "series": "stats.timers.grafana.dev.alert-dispatcher.get-schedules.median",
-              "target": ""
+              "target": "alias(stats.timers.grafana.dev.alert-dispatcher.get-schedules.median, 'median')"
             },
             {
-              "alias": "upper",
-              "column": "value",
-              "function": "mean",
-              "query": "select mean(value) from \"stats.timers.grafana.dev.alert-dispatcher.get-schedules.upper\" where $timeFilter group by time($interval) order asc",
-              "series": "stats.timers.grafana.dev.alert-dispatcher.get-schedules.upper",
-              "target": ""
+              "target": "alias(stats.timers.grafana.dev.alert-dispatcher.get-schedules.upper, 'upper')"
             }
           ],
           "timeFrom": null,
@@ -267,7 +233,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -307,26 +273,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "schedules seen per second",
-              "column": "value",
-              "fill": "0",
-              "function": "mean",
-              "hide": false,
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.grafana.dev.alert-dispatcher.job-schedules-seen\" where $timeFilter group by time($interval) fill(0) order asc",
-              "series": "stats.grafana.dev.alert-dispatcher.job-schedules-seen",
-              "target": "stats.grafana.dev.alert-dispatcher.job-schedules-seen"
+              "target": "alias(stats.grafana.dev.alert-dispatcher.job-schedules-seen, 'schedules seen per second')"
             },
             {
-              "alias": "jobs scheduled per second",
-              "column": "value",
-              "fill": "0",
-              "function": "first",
-              "hide": false,
-              "interval": "1s",
-              "query": "select first(value) from \"stats.grafana.dev.alert-dispatcher.jobs-scheduled\" where $timeFilter group by time($interval) fill(0) order asc",
-              "series": "stats.grafana.dev.alert-dispatcher.jobs-scheduled",
-              "target": ""
+              "target": "alias(stats.grafana.dev.alert-dispatcher.jobs-scheduled, 'jobs scheduled per second')"
             }
           ],
           "timeFrom": null,
@@ -358,7 +308,7 @@
             "skipped": "#890F02"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -403,37 +353,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "items",
-              "column": "value",
-              "fill": "0",
-              "function": "mean",
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.gauges.grafana.dev.alert-jobqueue-preamqp.items\" where $timeFilter group by time($interval) fill(0) order asc",
-              "series": "stats.gauges.grafana.dev.alert-jobqueue-preamqp.items",
-              "target": "",
-              "refId": "A"
+              "series": "alias(stats.gauges.grafana.dev.alert-jobqueue-preamqp.items, 'items')"
             },
             {
-              "alias": "size",
-              "column": "value",
-              "fill": "null",
-              "function": "mean",
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.gauges.grafana.dev.alert-jobqueue-preamqp.size\" where $timeFilter group by time($interval) fill(null) order asc",
-              "series": "stats.gauges.grafana.dev.alert-jobqueue-preamqp.size",
-              "target": "",
-              "refId": "A"
+              "series": "alias(stats.gauges.grafana.dev.alert-jobqueue-preamqp.size, 'size')"
             },
             {
-              "alias": "skipped",
-              "column": "value",
-              "fill": "0",
-              "function": "mean",
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-preamqp-jobqueue\" where $timeFilter group by time($interval) fill(0) order asc",
-              "series": "stats.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-preamqp-jobqueue",
-              "target": "",
-              "refId": "A"
+              "target": "alias(stats.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-preamqp-jobqueue, 'skipped')"
             }
           ],
           "timeFrom": null,
@@ -457,7 +383,7 @@
             "skipped": "#890F02"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -502,37 +428,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "items",
-              "column": "value",
-              "fill": "0",
-              "function": "mean",
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.gauges.grafana.dev.alert-jobqueue-internal.items\" where $timeFilter group by time($interval) fill(0) order asc",
-              "series": "stats.gauges.grafana.dev.alert-jobqueue-internal.items",
-              "target": "",
-              "refId": "A"
+              "target": "alias(stats.gauges.grafana.dev.alert-jobqueue-internal.items, 'items')"
             },
             {
-              "alias": "size",
-              "column": "value",
-              "fill": "null",
-              "function": "mean",
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.gauges.grafana.dev.alert-jobqueue-internal.size\" where $timeFilter group by time($interval) fill(null) order asc",
-              "series": "stats.gauges.grafana.dev.alert-jobqueue-internal.size",
-              "target": "",
-              "refId": "A"
+              "target": "alias(stats.gauges.grafana.dev.alert-jobqueue-internal.size, 'size')"
             },
             {
-              "alias": "skipped",
-              "column": "value",
-              "fill": "0",
-              "function": "mean",
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-internal-jobqueue\" where $timeFilter group by time($interval) fill(0) order asc",
-              "series": "stats.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-internal-jobqueue",
-              "target": "",
-              "refId": "A"
+              "target": "stats.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-internal-jobqueue, 'skipped')"
             }
           ],
           "timeFrom": null,
@@ -576,7 +478,7 @@
             "out of date": "#F29191"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -616,25 +518,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "todo",
-              "column": "value",
-              "fill": "0",
-              "function": "mean",
-              "hide": false,
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.grafana.dev.alert-executor.original-todo\" where $timeFilter group by time($interval) fill(0) order asc",
-              "series": "stats.grafana.dev.alert-executor.original-todo",
-              "target": ""
+            "target": "alias(stats.grafana.dev.alert-executor.original-todo, 'query')"
             },
             {
-              "alias": "already done",
-              "column": "value",
-              "fill": "0",
-              "function": "mean",
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.grafana.dev.alert-executor.already-done\" where $timeFilter group by time($interval) fill(0) order asc",
-              "series": "stats.grafana.dev.alert-executor.already-done",
-              "target": ""
+              "target": "alias(stats.grafana.dev.alert-executor.already-done, 'alreaday done')"
             }
           ],
           "timeFrom": null,
@@ -660,7 +547,7 @@
             "query-graphite-mean": "#C15C17"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -713,55 +600,19 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "parse-evaluate mean",
-              "column": "value",
-              "fill": "null",
-              "function": "mean",
-              "interval": "",
-              "query": "select mean(value) from \"stats.timers.grafana.dev.alert-executor.job_parse-and-evaluate.mean\" where $timeFilter group by time($interval) fill(null) order asc",
-              "refId": "A",
-              "series": "stats.timers.grafana.dev.alert-executor.job_parse-and-evaluate.mean",
-              "target": ""
+              "target": "alias(stats.timers.grafana.dev.alert-executor.job_parse-and-evaluate.mean, 'parse evaluate mean')"
             },
             {
-              "alias": "parse-evaluate upper",
-              "column": "value",
-              "fill": "null",
-              "function": "mean",
-              "query": "select mean(value) from \"stats.timers.grafana.dev.alert-executor.job_parse-and-evaluate.upper\" where $timeFilter group by time($interval) fill(null) order asc",
-              "refId": "A",
-              "series": "stats.timers.grafana.dev.alert-executor.job_parse-and-evaluate.upper",
-              "target": ""
+              "target": "alias(stats.timers.grafana.dev.alert-executor.job_parse-and-evaluate.upper, 'parse-evaluate upper')"
             },
             {
-              "alias": "query-graphite-mean",
-              "column": "value",
-              "fill": "null",
-              "function": "mean",
-              "query": "select mean(value) from \"stats.timers.grafana.dev.alert-executor.job_query_graphite.mean\" where $timeFilter group by time($interval) fill(null) order asc",
-              "refId": "A",
-              "series": "stats.timers.grafana.dev.alert-executor.job_query_graphite.mean",
-              "target": ""
+              "target": "alias(stats.timers.grafana.dev.alert-executor.job_query_graphite.mean, 'query-graphite mean')"
             },
             {
-              "alias": "query-graphite upper",
-              "column": "value",
-              "fill": "null",
-              "function": "mean",
-              "query": "select mean(value) from \"stats.timers.grafana.dev.alert-executor.job_query_graphite.upper\" where $timeFilter group by time($interval) fill(null) order asc",
-              "refId": "A",
-              "series": "stats.timers.grafana.dev.alert-executor.job_query_graphite.upper",
-              "target": ""
+              "target": "alias(stats.timers.grafana.dev.alert-executor.job_query_graphite.upper, 'query-graphite upper')"
             },
             {
-              "alias": "num executors",
-              "column": "value",
-              "fill": "null",
-              "function": "mean",
-              "query": "select mean(value) from /stats.gauges.grafana.dev.alert-executor.*num/ where $timeFilter group by time($interval) fill(null) order asc",
-              "refId": "A",
-              "series": "/stats.gauges.grafana.dev.alert-executor.*num/",
-              "target": ""
+              "target": "alias(sum(stats.gauges.grafana.dev.alert-executor.*num), 'num executors')"
             }
           ],
           "timeFrom": null,
@@ -785,7 +636,7 @@
             "unknown": "#806EB7"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -837,74 +688,19 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "ok",
-              "column": "value",
-              "fill": "null",
-              "function": "mean",
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.grafana.dev.alert-executor.alert-outcomes.ok\" where $timeFilter group by time($interval) fill(null) order asc",
-              "refId": "A",
-              "series": "stats.grafana.dev.alert-executor.alert-outcomes.ok",
-              "target": ""
+              "target": "stats.grafana.dev.alert-executor.alert-outcomes.*"
             },
             {
-              "alias": "crit",
-              "column": "value",
-              "fill": "null",
-              "function": "mean",
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.grafana.dev.alert-executor.alert-outcomes.critical\" where $timeFilter group by time($interval) fill(null) order asc",
-              "refId": "A",
-              "series": "stats.grafana.dev.alert-executor.alert-outcomes.critical",
-              "target": ""
+              "target": "alias(stats.timers.grafana.dev.alert-executor.graphite-missingVals.sum, 'missing-values')"
             },
             {
-              "alias": "unknown",
-              "column": "value",
-              "fill": "null",
-              "function": "mean",
-              "hide": false,
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.grafana.dev.alert-executor.alert-outcomes.unknown\" where $timeFilter group by time($interval) fill(null) order asc",
-              "refId": "A",
-              "series": "stats.grafana.dev.alert-executor.alert-outcomes.unknown",
-              "target": ""
+              "target": "alias(stats.grafana.dev.alert-executor.graphite-emptyresponse, 'empty-response')"
             },
             {
-              "alias": "missing-values",
-              "column": "value",
-              "fill": "null",
-              "function": "mean",
-              "hide": false,
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.timers.grafana.dev.alert-executor.graphite-missingVals.sum\" where $timeFilter group by time($interval) fill(null) order asc",
-              "refId": "A",
-              "series": "stats.timers.grafana.dev.alert-executor.graphite-missingVals.sum",
-              "target": ""
+              "query": "alias(stats.timers.grafana.dev.alert-executor.job_execution_delay.mean, 'execution delay mean')"
             },
             {
-              "alias": "empty response",
-              "column": "value",
-              "fill": "null",
-              "function": "mean",
-              "hide": false,
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.grafana.dev.alert-executor.graphite-emptyresponse\" where $timeFilter group by time($interval) fill(null) order asc",
-              "refId": "A",
-              "series": "stats.grafana.dev.alert-executor.graphite-emptyresponse",
-              "target": ""
-            },
-            {
-              "alias": "execution delay mean",
-              "query": "select mean(value) from \"stats.timers.grafana.dev.alert-executor.job_execution_delay.mean\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "B"
-            },
-            {
-              "alias": "execution delay p90",
-              "query": "select mean(value) from \"stats.timers.grafana.dev.alert-executor.job_execution_delay.upper_90\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "C"
+              "query": "alias(stats.timers.grafana.dev.alert-executor.job_execution_delay.upper_90, 'execution delay p90')"
             }
           ],
           "timeFrom": null,

--- a/grafana-dev/dashboards/alerting.json
+++ b/grafana-dev/dashboards/alerting.json
@@ -534,7 +534,7 @@
               "refId": "A"
             },
             {
-              "target": "alias(stats.$environment.grafana.dev.alert-executor.already-done, 'alreaday done')",
+              "target": "alias(stats.$environment.grafana.dev.alert-executor.already-done, 'already done')",
               "refId": "B"
             }
           ],
@@ -707,7 +707,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "stats.$environment.grafana.dev.alert-executor.alert-outcomes.*",
+              "target": "aliasByNode(stats.$environment.grafana.dev.alert-executor.alert-outcomes.*,6)",
               "refId": "A"
             },
             {

--- a/grafana-dev/dashboards/alerting.json
+++ b/grafana-dev/dashboards/alerting.json
@@ -61,13 +61,16 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.timers.grafana.dev.alert-tickqueue.items.mean, 'tickqueue items')"
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-tickqueue.items.mean, 'tickqueue items')",
+              "refId": "A"
             },
             {
-              "target": "alias(stats.gauges.grafana.dev.alert-tickqueue.size, 'tickqueue size')"
+              "target": "alias(stats.$environment.gauges.grafana.dev.alert-tickqueue.size, 'tickqueue size')",
+              "refId": "B"
             },
             {
-              "target": "alias(stats.grafana.dev.alert-dispatcher.ticks-skipped-due-to-slow-tickqueue, 'skipped')"
+              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.ticks-skipped-due-to-slow-tickqueue, 'skipped')",
+              "refId": "C"
             }
           ],
           "timeFrom": null,
@@ -148,7 +151,8 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "stats.grafana.dev.alert-dispatcher.num-getschedules"
+              "target": "stats.$environment.grafana.dev.alert-dispatcher.num-getschedules",
+              "refId": "A"
             }
           ],
           "timeFrom": null,
@@ -209,10 +213,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.timers.grafana.dev.alert-dispatcher.get-schedules.median, 'median')"
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-dispatcher.get-schedules.median, 'median')",
+              "refId": "A"
             },
             {
-              "target": "alias(stats.timers.grafana.dev.alert-dispatcher.get-schedules.upper, 'upper')"
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-dispatcher.get-schedules.upper, 'upper')",
+              "refId": "B"
             }
           ],
           "timeFrom": null,
@@ -273,10 +279,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.grafana.dev.alert-dispatcher.job-schedules-seen, 'schedules seen per second')"
+              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.job-schedules-seen, 'schedules seen per second')",
+              "refId": "A"
             },
             {
-              "target": "alias(stats.grafana.dev.alert-dispatcher.jobs-scheduled, 'jobs scheduled per second')"
+              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.jobs-scheduled, 'jobs scheduled per second')",
+              "refId": "B"
             }
           ],
           "timeFrom": null,
@@ -353,13 +361,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "series": "alias(stats.gauges.grafana.dev.alert-jobqueue-preamqp.items, 'items')"
+              "series": "alias(stats.$environment.gauges.grafana.dev.alert-jobqueue-preamqp.items, 'items')"
             },
             {
-              "series": "alias(stats.gauges.grafana.dev.alert-jobqueue-preamqp.size, 'size')"
+              "series": "alias(stats.$environment.gauges.grafana.dev.alert-jobqueue-preamqp.size, 'size')"
             },
             {
-              "target": "alias(stats.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-preamqp-jobqueue, 'skipped')"
+              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-preamqp-jobqueue, 'skipped')",
+              "refId": "C"
             }
           ],
           "timeFrom": null,
@@ -428,13 +437,16 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.gauges.grafana.dev.alert-jobqueue-internal.items, 'items')"
+              "target": "alias(stats.$environment.gauges.grafana.dev.alert-jobqueue-internal.items, 'items')",
+              "refId": "A"
             },
             {
-              "target": "alias(stats.gauges.grafana.dev.alert-jobqueue-internal.size, 'size')"
+              "target": "alias(stats.$environment.gauges.grafana.dev.alert-jobqueue-internal.size, 'size')",
+              "refId": "B"
             },
             {
-              "target": "stats.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-internal-jobqueue, 'skipped')"
+              "target": "stats.$environment.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-internal-jobqueue, 'skipped')",
+              "refId": "C"
             }
           ],
           "timeFrom": null,
@@ -518,10 +530,12 @@
           "steppedLine": false,
           "targets": [
             {
-            "target": "alias(stats.grafana.dev.alert-executor.original-todo, 'query')"
+              "target": "alias(stats.$environment.grafana.dev.alert-executor.original-todo, 'query')",
+              "refId": "A"
             },
             {
-              "target": "alias(stats.grafana.dev.alert-executor.already-done, 'alreaday done')"
+              "target": "alias(stats.$environment.grafana.dev.alert-executor.already-done, 'alreaday done')",
+              "refId": "B"
             }
           ],
           "timeFrom": null,
@@ -589,10 +603,10 @@
             {
               "alias": "num executors",
               "fill": 2,
-              "linewidth": 0,
-              "yaxis": 2,
               "lines": true,
-              "points": false
+              "linewidth": 0,
+              "points": false,
+              "yaxis": 2
             }
           ],
           "span": 4,
@@ -600,19 +614,24 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.timers.grafana.dev.alert-executor.job_parse-and-evaluate.mean, 'parse evaluate mean')"
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_parse-and-evaluate.mean, 'parse evaluate mean')",
+              "refId": "A"
             },
             {
-              "target": "alias(stats.timers.grafana.dev.alert-executor.job_parse-and-evaluate.upper, 'parse-evaluate upper')"
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_parse-and-evaluate.upper, 'parse-evaluate upper')",
+              "refId": "B"
             },
             {
-              "target": "alias(stats.timers.grafana.dev.alert-executor.job_query_graphite.mean, 'query-graphite mean')"
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_query_graphite.mean, 'query-graphite mean')",
+              "refId": "C"
             },
             {
-              "target": "alias(stats.timers.grafana.dev.alert-executor.job_query_graphite.upper, 'query-graphite upper')"
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_query_graphite.upper, 'query-graphite upper')",
+              "refId": "D"
             },
             {
-              "target": "alias(sum(stats.gauges.grafana.dev.alert-executor.*num), 'num executors')"
+              "target": "alias(sum(stats.$environment.gauges.grafana.dev.alert-executor.*num), 'num executors')",
+              "refId": "E"
             }
           ],
           "timeFrom": null,
@@ -688,19 +707,22 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "stats.grafana.dev.alert-executor.alert-outcomes.*"
+              "target": "stats.$environment.grafana.dev.alert-executor.alert-outcomes.*",
+              "refId": "A"
             },
             {
-              "target": "alias(stats.timers.grafana.dev.alert-executor.graphite-missingVals.sum, 'missing-values')"
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.graphite-missingVals.sum, 'missing-values')",
+              "refId": "B"
             },
             {
-              "target": "alias(stats.grafana.dev.alert-executor.graphite-emptyresponse, 'empty-response')"
+              "target": "alias(stats.$environment.grafana.dev.alert-executor.graphite-emptyresponse, 'empty-response')",
+              "refId": "C"
             },
             {
-              "query": "alias(stats.timers.grafana.dev.alert-executor.job_execution_delay.mean, 'execution delay mean')"
+              "query": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_execution_delay.mean, 'execution delay mean')"
             },
             {
-              "query": "alias(stats.timers.grafana.dev.alert-executor.job_execution_delay.upper_90, 'execution delay p90')"
+              "query": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_execution_delay.upper_90, 'execution delay p90')"
             }
           ],
           "timeFrom": null,
@@ -758,22 +780,46 @@
     "type": "timepicker"
   },
   "templating": {
-    "list": []
+    "list": [
+      {
+        "type": "query",
+        "datasource": "graphite",
+        "refresh_on_load": false,
+        "name": "environment",
+        "options": [
+          {
+            "text": "raintank-docker",
+            "value": "raintank-docker",
+            "selected": true
+          }
+        ],
+        "includeAll": false,
+        "allFormat": "glob",
+        "multi": false,
+        "multiFormat": "glob",
+        "query": "stats.*",
+        "current": {
+          "text": "raintank-docker",
+          "value": "raintank-docker",
+          "tags": []
+        }
+      }
+    ]
   },
   "annotations": {
     "list": [
       {
-        "name": "events",
         "datasource": "influxdb",
-        "showLine": true,
-        "iconColor": "#C0C6BE",
-        "lineColor": "rgba(255, 96, 96, 0.592157)",
-        "iconSize": 13,
         "enable": true,
+        "iconColor": "#C0C6BE",
+        "iconSize": 13,
+        "lineColor": "rgba(255, 96, 96, 0.592157)",
+        "name": "events",
         "query": "select type, text from events where $timeFilter",
-        "titleColumn": "type",
+        "showLine": true,
         "tagsColumn": "tags",
-        "textColumn": "text"
+        "textColumn": "text",
+        "titleColumn": "type"
       }
     ]
   },

--- a/grafana-dev/dashboards/nsq-metric-tank.json
+++ b/grafana-dev/dashboards/nsq-metric-tank.json
@@ -17,7 +17,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 10,
@@ -57,11 +57,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "metrics in",
-              "query": "select mean(value) from \"stats.metric_tank.metricstank.metrics_received\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "A",
-              "target": ""
+              "target": "alias(stats.metric_tank.metricstank.metrics_received, 'metrics in')"
             }
           ],
           "timeFrom": null,
@@ -128,54 +124,29 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "alloc incl freed",
-              "column": "value",
-              "datasource": "influxdb",
+              "datasource": "graphite",
               "hide": true,
-              "query": "select mean(value) from \"stats.gauges.metric_tank.metricstank.bytes_alloc.incl_freed\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "A",
-              "series": "metrics.metric_tank.5-120.bytes_alloc_incl_freed.value"
+              "target": "alias(stats.gauges.metric_tank.metricstank.bytes_alloc.incl_freed, 'alloc incl freed')"
             },
             {
-              "alias": "alloc not freed",
-              "column": "value",
-              "datasource": "influxdb",
+              "datasource": "graphite",
               "hide": false,
-              "query": "select mean(value) from \"stats.gauges.metric_tank.metricstank.bytes_alloc.not_freed\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "B",
-              "series": "metrics.metric_tank.5-120.bytes_alloc_not_freed.value"
+              "target": "alias(stats.gauges.metric_tank.metricstank.bytes_alloc.not_freed, 'alloc not freed')"
             },
             {
-              "alias": "bytes_sys",
-              "column": "value",
-              "datasource": "influxdb",
+              "datasource": "graphite",
               "hide": false,
-              "query": "select mean(value) from \"stats.gauges.metric_tank.metricstank.bytes_sys\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "C",
-              "series": "metrics.metric_tank.5-120.bytes_sys.value"
+              "target": "alias(stats.gauges.metric_tank.metricstank.bytes_sys, 'bytes_sys')"
             },
             {
-              "alias": "active metrics",
-              "column": "value",
-              "datasource": "influxdb",
+              "datasource": "graphite",
               "hide": false,
-              "query": "select mean(value) from \"stats.gauges.metric_tank.metricstank.metrics_active\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "D",
-              "series": "metrics.metric_tank.5-120.metrics_active.value"
+              "target": "alias(stats.gauges.metric_tank.metricstank.metrics_active, 'metrics_active')"
             },
             {
-              "alias": "points per metric",
-              "column": "value",
-              "datasource": "influxdb",
+              "datasource": "graphite",
               "hide": false,
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.points_per_metric.mean\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "E",
-              "series": "metrics.metric_tank.5-120.metrics_active.value"
+              "target": "alias(stats.timers.metric_tank.metricstank.points_per_metric.mean, 'points per metric')"
             }
           ],
           "timeFrom": null,
@@ -202,7 +173,7 @@
             "median": "#3F6833"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -242,54 +213,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "median",
-              "column": "value",
               "hide": false,
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.points_per_metric.median\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "A",
-              "series": "stats.timers.metric_tank.metricstank.points_per_metric.median",
-              "target": ""
+              "target": "stats.timers.metric_tank.metricstank.points_per_metric.median"
             },
             {
-              "alias": "99th",
-              "column": "value",
               "hide": false,
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.points_per_metric.median\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "B",
-              "series": "stats.timers.metric_tank.metricstank.points_per_metric.median",
-              "target": ""
-            },
-            {
-              "alias": "90th",
-              "column": "value",
-              "hide": false,
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.points_per_metric.upper_90\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "C",
-              "series": "stats.timers.metric_tank.metricstank.points_per_metric.median",
-              "target": ""
-            },
-            {
-              "alias": "upper",
-              "column": "value",
-              "hide": false,
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.points_per_metric.upper\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "D",
-              "series": "stats.timers.metric_tank.metricstank.points_per_metric.999-percentile",
-              "target": ""
-            },
-            {
-              "alias": "mean",
-              "column": "value",
-              "hide": false,
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.points_per_metric.mean\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "E",
-              "series": "stats.timers.metric_tank.metricstank.points_per_metric.median",
-              "target": ""
+              "target": "stats.timers.metric_tank.metricstank.points_per_metric.999-percentile"
             }
           ],
           "timeFrom": null,
@@ -327,7 +256,7 @@
             "mem-cass p90": "#EF843C"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -367,84 +296,36 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "mem-cass min",
-              "column": "value",
               "hide": false,
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "A",
-              "series": "stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower",
-              "target": ""
+              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower, 'mem-cass min')"
             },
             {
-              "alias": "mem-cass p90",
-              "column": "value",
               "hide": true,
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper_90\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "C",
-              "series": "stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower",
-              "target": ""
+              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper_90, 'mem-cass p90')"
             },
             {
-              "alias": "mem-cass med",
-              "column": "value",
               "hide": false,
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.median\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "D",
-              "series": "stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower",
-              "target": ""
+              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.median, 'mem-cass med')"
             },
             {
-              "alias": "mem-cass max",
-              "column": "value",
               "hide": false,
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "B",
-              "series": "stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower",
-              "target": ""
+              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper, 'mem-cass max')"
             },
             {
-              "alias": "mem min",
-              "column": "value",
               "hide": false,
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.requests_span.mem.lower\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "E",
-              "series": "stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower",
-              "target": ""
+              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem.lower, 'mem min')"
             },
             {
-              "alias": "mem med",
-              "column": "value",
               "hide": false,
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.requests_span.mem.median\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "F",
-              "series": "stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower",
-              "target": ""
+              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem.median, 'mem med')"
             },
             {
-              "alias": "mem p90",
-              "column": "value",
               "hide": true,
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.requests_span.mem.upper_90\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "G",
-              "series": "stats.timers.metric_tank.metricstank.requests_span.mem.lower",
-              "target": ""
+              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem.upper_90, 'mem p90')"
             },
             {
-              "alias": "mem max",
-              "column": "value",
               "hide": false,
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.requests_span.mem.upper\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "H",
-              "series": "stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower",
-              "target": ""
+              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem.upper, 'mem max')"
             }
           ],
           "timeFrom": null,
@@ -474,7 +355,7 @@
             "mem-cass p90": "#EF843C"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -514,24 +395,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "mem-cass req/s",
-              "column": "value",
               "hide": false,
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.count_ps\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "I",
-              "series": "stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower",
-              "target": ""
+              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.count_ps, 'mem-cass req/s')"
             },
             {
-              "alias": "mem req/s",
-              "column": "value",
               "hide": false,
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.requests_span.mem.count_ps\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "J",
-              "series": "stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower",
-              "target": ""
+              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem.count_ps, 'mem req/s')"
             }
           ],
           "timeFrom": null,
@@ -556,7 +425,7 @@
             "median": "#CCA300"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -596,33 +465,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "median",
-              "column": "value",
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.request_handle_duration.median\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "A",
-              "series": "stats.timers.metric_tank.metricstank.request_handle_duration.median",
-              "target": ""
+              "target": "alias(stats.timers.metric_tank.metricstank.request_handle_duration.median, 'median')"
             },
             {
-              "alias": "p90",
-              "column": "value",
-              "hide": false,
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.request_handle_duration.upper_90\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "B",
-              "series": "stats.timers.metric_tank.metricstank.request_handle_duration.median",
-              "target": ""
+              "target": "alias(stats.timers.metric_tank.metricstank.request_handle_duration.upper_90, 'p90')"
             },
             {
-              "alias": "max",
-              "column": "value",
-              "hide": false,
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.request_handle_duration.upper\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "C",
-              "series": "stats.timers.metric_tank.metricstank.request_handle_duration.median",
-              "target": ""
+              "target": "alias(stats.timers.metric_tank.metricstank.request_handle_duration.upper, 'max')"
             }
           ],
           "timeFrom": null,
@@ -658,7 +507,7 @@
             "size at save p90": "#65C5DB"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -698,52 +547,22 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "size at load median",
-              "column": "value",
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.chunk_size.at_load.median\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "A",
-              "series": "stats.timers.metric_tank.metricstank.chunk_size.at_load.mean"
+              "target": "alias(stats.timers.metric_tank.metricstank.chunk_size.at_load.median, 'size at load median')"
             },
             {
-              "alias": "size at load p90",
-              "column": "value",
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.chunk_size.at_load.upper_90\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "B",
-              "series": "stats.timers.metric_tank.metricstank.chunk_size.at_load.mean"
+              "target": "alias(stats.timers.metric_tank.metricstank.chunk_size.at_load.upper_90, 'size at load p90')"
             },
             {
-              "alias": "size at load max",
-              "column": "value",
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.chunk_size.at_load.upper\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "C",
-              "series": "stats.timers.metric_tank.metricstank.chunk_size.at_load.mean"
+              "target": "alias(stats.timers.metric_tank.metricstank.chunk_size.at_load.upper, 'size at load max')"
             },
             {
-              "alias": "size at save median",
-              "column": "value",
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.chunk_size.at_save.median\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "D",
-              "series": "stats.timers.metric_tank.metricstank.chunk_size.at_load.mean"
+              "target": "alias(stats.timers.metric_tank.metricstank.chunk_size.at_save.median, 'size at save median')"
             },
             {
-              "alias": "size at save p90",
-              "column": "value",
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.chunk_size.at_save.upper_90\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "E",
-              "series": "stats.timers.metric_tank.metricstank.chunk_size.at_load.mean"
+              "target": "alias(stats.timers.metric_tank.metricstank.chunk_size.at_save.upper_90, 'size at save p90')"
             },
             {
-              "alias": "size at save max",
-              "column": "value",
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.chunk_size.at_save.upper\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "F",
-              "series": "stats.timers.metric_tank.metricstank.chunk_size.at_load.mean"
+              "target": "alias(stats.timers.metric_tank.metricstank.chunk_size.at_save.upper, 'size at save max')"
             }
           ],
           "timeFrom": null,
@@ -772,7 +591,7 @@
             "put/s": "#BF1B00"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -812,20 +631,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "put/s",
-              "column": "value",
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.cassandra_put_duration.count_ps\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "E",
-              "series": "stats.timers.metric_tank.metricstank.cassandra_put_duration.upper_90"
+              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_put_duration.count_ps, 'put/s')"
             },
             {
-              "alias": "get/s",
-              "column": "value",
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.cassandra_get_duration.count_ps\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "F",
-              "series": "stats.timers.metric_tank.metricstank.cassandra_put_duration.upper_90"
+              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_get_duration.count_ps, 'get/s')"
             }
           ],
           "timeFrom": null,
@@ -854,7 +663,7 @@
             "put/s": "#BF1B00"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -894,36 +703,16 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "put p90",
-              "column": "value",
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.cassandra_put_duration.upper_90\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "A",
-              "series": "stats.timers.metric_tank.metricstank.cassandra_put_duration.upper_90"
+              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_put_duration.upper_90, 'put p90')"
             },
             {
-              "alias": "put mean",
-              "column": "value",
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.cassandra_put_duration.mean\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "B",
-              "series": "stats.timers.metric_tank.metricstank.cassandra_put_duration.upper_90"
+              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_put_duration.mean, 'put mean')"
             },
             {
-              "alias": "get p90",
-              "column": "value",
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.cassandra_get_duration.upper_90\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "C",
-              "series": "stats.timers.metric_tank.metricstank.cassandra_put_duration.upper_90"
+              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_get_duration.upper_90, 'get p90')"
             },
             {
-              "alias": "get mean",
-              "column": "value",
-              "query": "select median(value) from \"stats.timers.metric_tank.metricstank.cassandra_get_duration.mean\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "D",
-              "series": "stats.timers.metric_tank.metricstank.cassandra_put_duration.upper_90"
+              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_get_duration.mean, 'get mean')"
             }
           ],
           "timeFrom": null,
@@ -959,7 +748,7 @@
             "rows per resp max": "#508642"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -1010,56 +799,22 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "chunks per row med",
-              "column": "value",
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.median\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": false,
-              "refId": "A",
-              "series": "stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.median",
-              "target": "",
-              "function": "mean"
+              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.median, 'chunks per row med')"
             },
             {
-              "refId": "C",
-              "function": "mean",
-              "column": "value",
-              "series": "stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.lower",
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.lower\" where $timeFilter group by time($interval) order asc",
-              "alias": "chunks per row min"
+              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.lower, 'chunks per row min')"
             },
             {
-              "refId": "D",
-              "function": "mean",
-              "column": "value",
-              "series": "stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.upper",
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.upper\" where $timeFilter group by time($interval) order asc",
-              "alias": "chunks per row max"
+              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.upper, 'chunks per row max')"
             },
             {
-              "alias": "rows per resp med",
-              "column": "value",
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.median\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": false,
-              "refId": "B",
-              "series": "stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.median",
-              "target": "",
-              "function": "mean"
+              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.median, 'rows per resp med')"
             },
             {
-              "refId": "E",
-              "function": "mean",
-              "column": "value",
-              "series": "stats.timers.metric_tank.metricstank.cassandra_rows_per_response.lower",
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.cassandra_rows_per_response.lower\" where $timeFilter group by time($interval) order asc",
-              "alias": "rows per resp min"
+              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_rows_per_response.lower, 'rows per resp min')"
             },
             {
-              "refId": "F",
-              "function": "mean",
-              "column": "value",
-              "series": "stats.timers.metric_tank.metricstank.cassandra_rows_per_response.upper",
-              "query": "select mean(value) from \"stats.timers.metric_tank.metricstank.cassandra_rows_per_response.upper\" where $timeFilter group by time($interval) order asc",
-              "alias": "rows per resp max"
+              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_rows_per_response.upper, 'rows per resp max')"
             }
           ],
           "timeFrom": null,
@@ -1084,7 +839,7 @@
             "save_ok/s": "#3F6833"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -1124,44 +879,16 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "create/s",
-              "column": "value",
-              "hide": false,
-              "query": "select median(value) from \"stats.metric_tank.metricstank.chunks.create\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "A",
-              "series": "stats.metric_tank.metricstank.chunks.create",
-              "target": ""
+              "target": "alias(stats.metric_tank.metricstank.chunks.create, 'create/s')"
             },
             {
-              "alias": "clear/s",
-              "column": "value",
-              "hide": false,
-              "query": "select median(value) from \"stats.metric_tank.metricstank.chunks.clear\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "B",
-              "series": "stats.metric_tank.metricstank.chunks.clear",
-              "target": ""
+              "target": "alias(stats.metric_tank.metricstank.chunks.clear, 'clear/s')"
             },
             {
-              "alias": "save_ok/s",
-              "column": "value",
-              "hide": false,
-              "query": "select median(value) from \"stats.metric_tank.metricstank.chunks.save_ok\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "C",
-              "series": "stats.metric_tank.metricstank.chunks.clear",
-              "target": ""
+              "target": "alias(stats.metric_tank.metricstank.chunks.save_ok, 'save_ok/s')"
             },
             {
-              "alias": "save_fail/s",
-              "column": "value",
-              "hide": false,
-              "query": "select median(value) from \"stats.metric_tank.metricstank.chunks.save_fail\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "D",
-              "series": "stats.metric_tank.metricstank.chunks.clear",
-              "target": ""
+              "target": "alias(stats.metric_tank.metricstank.chunks.save_fail, 'save_fail/s')"
             }
           ],
           "timeFrom": null,

--- a/grafana-dev/dashboards/nsq-metric-tank.json
+++ b/grafana-dev/dashboards/nsq-metric-tank.json
@@ -57,7 +57,8 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.metric_tank.metricstank.metrics_received, 'metrics in')"
+              "target": "alias(stats.$environment.metric_tank.metricstank.metrics_received, 'metrics in')",
+              "refId": "A"
             }
           ],
           "timeFrom": null,
@@ -126,27 +127,32 @@
             {
               "datasource": "graphite",
               "hide": true,
-              "target": "alias(stats.gauges.metric_tank.metricstank.bytes_alloc.incl_freed, 'alloc incl freed')"
+              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.bytes_alloc.incl_freed, 'alloc incl freed')",
+              "refId": "A"
             },
             {
               "datasource": "graphite",
               "hide": false,
-              "target": "alias(stats.gauges.metric_tank.metricstank.bytes_alloc.not_freed, 'alloc not freed')"
+              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.bytes_alloc.not_freed, 'alloc not freed')",
+              "refId": "B"
             },
             {
               "datasource": "graphite",
               "hide": false,
-              "target": "alias(stats.gauges.metric_tank.metricstank.bytes_sys, 'bytes_sys')"
+              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.bytes_sys, 'bytes_sys')",
+              "refId": "C"
             },
             {
               "datasource": "graphite",
               "hide": false,
-              "target": "alias(stats.gauges.metric_tank.metricstank.metrics_active, 'metrics_active')"
+              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.metrics_active, 'metrics_active')",
+              "refId": "D"
             },
             {
               "datasource": "graphite",
               "hide": false,
-              "target": "alias(stats.timers.metric_tank.metricstank.points_per_metric.mean, 'points per metric')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.points_per_metric.mean, 'points per metric')",
+              "refId": "E"
             }
           ],
           "timeFrom": null,
@@ -214,11 +220,13 @@
           "targets": [
             {
               "hide": false,
-              "target": "stats.timers.metric_tank.metricstank.points_per_metric.median"
+              "target": "stats.$environment.timers.metric_tank.metricstank.points_per_metric.median",
+              "refId": "A"
             },
             {
               "hide": false,
-              "target": "stats.timers.metric_tank.metricstank.points_per_metric.999-percentile"
+              "target": "stats.$environment.timers.metric_tank.metricstank.points_per_metric.999-percentile",
+              "refId": "B"
             }
           ],
           "timeFrom": null,
@@ -297,35 +305,43 @@
           "targets": [
             {
               "hide": false,
-              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower, 'mem-cass min')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower, 'mem-cass min')",
+              "refId": "A"
             },
             {
               "hide": true,
-              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper_90, 'mem-cass p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper_90, 'mem-cass p90')",
+              "refId": "B"
             },
             {
               "hide": false,
-              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.median, 'mem-cass med')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.median, 'mem-cass med')",
+              "refId": "C"
             },
             {
               "hide": false,
-              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper, 'mem-cass max')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper, 'mem-cass max')",
+              "refId": "D"
             },
             {
               "hide": false,
-              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem.lower, 'mem min')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.lower, 'mem min')",
+              "refId": "E"
             },
             {
               "hide": false,
-              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem.median, 'mem med')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.median, 'mem med')",
+              "refId": "F"
             },
             {
               "hide": true,
-              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem.upper_90, 'mem p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.upper_90, 'mem p90')",
+              "refId": "G"
             },
             {
               "hide": false,
-              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem.upper, 'mem max')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.upper, 'mem max')",
+              "refId": "H"
             }
           ],
           "timeFrom": null,
@@ -396,11 +412,13 @@
           "targets": [
             {
               "hide": false,
-              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.count_ps, 'mem-cass req/s')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.count_ps, 'mem-cass req/s')",
+              "refId": "A"
             },
             {
               "hide": false,
-              "target": "alias(stats.timers.metric_tank.metricstank.requests_span.mem.count_ps, 'mem req/s')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.count_ps, 'mem req/s')",
+              "refId": "B"
             }
           ],
           "timeFrom": null,
@@ -421,8 +439,8 @@
         {
           "aliasColors": {
             "max": "#890F02",
-            "p90": "#C15C17",
-            "median": "#CCA300"
+            "median": "#CCA300",
+            "p90": "#C15C17"
           },
           "bars": false,
           "datasource": "graphite",
@@ -465,13 +483,16 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.request_handle_duration.median, 'median')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.request_handle_duration.median, 'median')",
+              "refId": "A"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.request_handle_duration.upper_90, 'p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.request_handle_duration.upper_90, 'p90')",
+              "refId": "B"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.request_handle_duration.upper, 'max')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.request_handle_duration.upper, 'max')",
+              "refId": "C"
             }
           ],
           "timeFrom": null,
@@ -547,22 +568,28 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.chunk_size.at_load.median, 'size at load median')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_load.median, 'size at load median')",
+              "refId": "A"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.chunk_size.at_load.upper_90, 'size at load p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_load.upper_90, 'size at load p90')",
+              "refId": "B"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.chunk_size.at_load.upper, 'size at load max')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_load.upper, 'size at load max')",
+              "refId": "C"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.chunk_size.at_save.median, 'size at save median')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_save.median, 'size at save median')",
+              "refId": "D"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.chunk_size.at_save.upper_90, 'size at save p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_save.upper_90, 'size at save p90')",
+              "refId": "E"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.chunk_size.at_save.upper, 'size at save max')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_save.upper, 'size at save max')",
+              "refId": "F"
             }
           ],
           "timeFrom": null,
@@ -631,10 +658,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_put_duration.count_ps, 'put/s')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_put_duration.count_ps, 'put/s')",
+              "refId": "A"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_get_duration.count_ps, 'get/s')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_get_duration.count_ps, 'get/s')",
+              "refId": "B"
             }
           ],
           "timeFrom": null,
@@ -703,16 +732,20 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_put_duration.upper_90, 'put p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_put_duration.upper_90, 'put p90')",
+              "refId": "A"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_put_duration.mean, 'put mean')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_put_duration.mean, 'put mean')",
+              "refId": "B"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_get_duration.upper_90, 'get p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_get_duration.upper_90, 'get p90')",
+              "refId": "C"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_get_duration.mean, 'get mean')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_get_duration.mean, 'get mean')",
+              "refId": "D"
             }
           ],
           "timeFrom": null,
@@ -741,11 +774,11 @@
         {
           "aliasColors": {
             "chunks per row max": "#C15C17",
-            "chunks per row min": "#E5AC0E",
             "chunks per row med": "#890F02",
+            "chunks per row min": "#E5AC0E",
+            "rows per resp max": "#508642",
             "rows per resp med": "#052B51",
-            "rows per resp min": "#6ED0E0",
-            "rows per resp max": "#508642"
+            "rows per resp min": "#6ED0E0"
           },
           "bars": false,
           "datasource": "graphite",
@@ -766,14 +799,14 @@
           },
           "id": 7,
           "legend": {
+            "alignAsTable": false,
             "avg": false,
             "current": false,
             "max": false,
             "min": false,
             "show": true,
             "total": false,
-            "values": false,
-            "alignAsTable": false
+            "values": false
           },
           "lines": false,
           "linewidth": 2,
@@ -799,22 +832,28 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.median, 'chunks per row med')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.median, 'chunks per row med')",
+              "refId": "A"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.lower, 'chunks per row min')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.lower, 'chunks per row min')",
+              "refId": "B"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.upper, 'chunks per row max')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.upper, 'chunks per row max')",
+              "refId": "C"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_chunks_per_row.median, 'rows per resp med')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.median, 'rows per resp med')",
+              "refId": "D"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_rows_per_response.lower, 'rows per resp min')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_rows_per_response.lower, 'rows per resp min')",
+              "refId": "E"
             },
             {
-              "target": "alias(stats.timers.metric_tank.metricstank.cassandra_rows_per_response.upper, 'rows per resp max')"
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_rows_per_response.upper, 'rows per resp max')",
+              "refId": "F"
             }
           ],
           "timeFrom": null,
@@ -879,16 +918,20 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.metric_tank.metricstank.chunks.create, 'create/s')"
+              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.create, 'create/s')",
+              "refId": "A"
             },
             {
-              "target": "alias(stats.metric_tank.metricstank.chunks.clear, 'clear/s')"
+              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.clear, 'clear/s')",
+              "refId": "B"
             },
             {
-              "target": "alias(stats.metric_tank.metricstank.chunks.save_ok, 'save_ok/s')"
+              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.save_ok, 'save_ok/s')",
+              "refId": "C"
             },
             {
-              "target": "alias(stats.metric_tank.metricstank.chunks.save_fail, 'save_fail/s')"
+              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.save_fail, 'save_fail/s')",
+              "refId": "D"
             }
           ],
           "timeFrom": null,
@@ -946,7 +989,31 @@
     "type": "timepicker"
   },
   "templating": {
-    "list": []
+    "list": [
+      {
+        "type": "query",
+        "datasource": "graphite",
+        "refresh_on_load": false,
+        "name": "environment",
+        "options": [
+          {
+            "text": "raintank-docker",
+            "value": "raintank-docker",
+            "selected": true
+          }
+        ],
+        "includeAll": false,
+        "allFormat": "glob",
+        "multi": false,
+        "multiFormat": "glob",
+        "query": "stats.*",
+        "current": {
+          "text": "raintank-docker",
+          "value": "raintank-docker"
+        },
+        "regex": ""
+      }
+    ]
   },
   "annotations": {
     "list": [
@@ -966,6 +1033,6 @@
     ]
   },
   "schemaVersion": 7,
-  "version": 1,
+  "version": 0,
   "links": []
 }

--- a/grafana-dev/dashboards/sys.json
+++ b/grafana-dev/dashboards/sys.json
@@ -202,10 +202,9 @@
       "title": "Row"
     },
     {
-      "title": "New row",
-      "height": "250px",
-      "editable": true,
       "collapse": false,
+      "editable": true,
+      "height": "250px",
       "panels": [
         {
           "aliasColors": {
@@ -391,7 +390,8 @@
             "short"
           ]
         }
-      ]
+      ],
+      "title": "New row"
     },
     {
       "collapse": false,
@@ -626,15 +626,15 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.timers.graphite-api.fetch.raintank_query.query_duration.mean, 'raintank_query mean')"
+              "target": "alias(stats.$environment.timers.graphite-api.fetch.raintank_query.query_duration.mean, 'raintank_query mean')"
             },
             {
               "refId": "B",
-              "target": "alias(stats.timers.graphite-api.fetch.unmarshal_raintank_resp.duration.mean, 'unmarshal raintank resp mean')"
+              "target": "alias(stats.$environment.timers.graphite-api.fetch.unmarshal_raintank_resp.duration.mean, 'unmarshal raintank resp mean')"
             },
             {
               "refId": "C",
-              "target": "alias(stats.timers.graphite-api.search_series.es_search.query_duration.mean, 'search ES mean')"
+              "target": "alias(stats.$environment.timers.graphite-api.search_series.es_search.query_duration.mean, 'search ES mean')"
             }
           ],
           "timeFrom": null,
@@ -704,15 +704,15 @@
           "targets": [
             {
               "refId": "D",
-              "target": "alias(stats.timers.graphite-api.fetch.raintank_query.query_duration.upper_90, 'raintank_query p90')"
+              "target": "alias(stats.$environment.timers.graphite-api.fetch.raintank_query.query_duration.upper_90, 'raintank_query p90')"
             },
             {
               "refId": "E",
-              "target": "alias(stats.timers.graphite-api.fetch.unmarshal_raintank_resp.duration.upper_90, 'unmarshal raintank resp p90')"
+              "target": "alias(stats.$environment.timers.graphite-api.fetch.unmarshal_raintank_resp.duration.upper_90, 'unmarshal raintank resp p90')"
             },
             {
               "refId": "F",
-              "target": "alias(stats.timers.graphite-api.search_series.es_search.query_duration.upper_90, 'search ES ps90')"
+              "target": "alias(stats.$environment.timers.graphite-api.search_series.es_search.query_duration.upper_90, 'search ES ps90')"
             }
           ],
           "timeFrom": null,
@@ -788,15 +788,15 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.timers.graphite-api.fetch.raintank_query.query_duration.count_ps, 'raintank query')"
+              "target": "alias(stats.$environment.timers.graphite-api.fetch.raintank_query.query_duration.count_ps, 'raintank query')"
             },
             {
               "refId": "B",
-              "target": "alias(stats.timers.graphite-api.fetch.unmarshal_raintank_resp.duration.count_ps, 'unmarshal raintank resp')"
+              "target": "alias(stats.$environment.timers.graphite-api.fetch.unmarshal_raintank_resp.duration.count_ps, 'unmarshal raintank resp')"
             },
             {
               "refId": "C",
-              "target": "alias(stats.timers.graphite-api.search_series.es_search.query_duration.count_ps, 'search ES')"
+              "target": "alias(stats.$environment.timers.graphite-api.search_series.es_search.query_duration.count_ps, 'search ES')"
             }
           ],
           "timeFrom": null,
@@ -849,7 +849,30 @@
     ]
   },
   "templating": {
-    "list": []
+    "list": [
+      {
+        "type": "query",
+        "datasource": "graphite",
+        "refresh_on_load": false,
+        "name": "environment",
+        "options": [
+          {
+            "text": "raintank-docker",
+            "value": "raintank-docker",
+            "selected": true
+          }
+        ],
+        "includeAll": false,
+        "allFormat": "glob",
+        "multi": false,
+        "multiFormat": "glob",
+        "query": "stats.*",
+        "current": {
+          "text": "raintank-docker",
+          "value": "raintank-docker"
+        }
+      }
+    ]
   },
   "annotations": {
     "list": [

--- a/grafana-dev/dashboards/sys.json
+++ b/grafana-dev/dashboards/sys.json
@@ -21,7 +21,7 @@
             "grafana": "#511749"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -61,138 +61,64 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "grafana",
-              "column": "value",
-              "query": "select mean(value) from \"measure.grafana_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "A",
-              "series": "measure.grafana_cpu",
-              "target": ""
+              "target": "alias(measure.grafana_cpu, 'grafana')"
             },
             {
-              "alias": "cassandra",
-              "column": "value",
-              "query": "select mean(value) from \"measure.cassandra_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "B",
-              "series": "measure.cassandra_cpu"
+              "target": "alias(measure.cassandra_cpu, 'cassandra')"
             },
             {
-              "alias": "kairosdb",
-              "column": "value",
-              "hide": true,
-              "query": "select mean(value) from \"measure.kairosdb_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "C",
-              "series": "measure.cassandra_cpu"
+              "target": "alias(measure.kairosdb_cpu, 'kairosdb')"
             },
             {
-              "alias": "NMT",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.nmt_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "D",
-              "series": "measure.cassandra_cpu"
+              "target": "alias(measure.nmt_cpu, 'nmt')"
             },
             {
-              "alias": "NMK",
-              "column": "value",
-              "hide": true,
-              "query": "select mean(value) from \"measure.nmk_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "E",
-              "series": "measure.cassandra_cpu"
+              "target": "alias(measure.nmk_cpu, 'nmk')"
             },
             {
-              "alias": "elasticsearch",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.elasticsearch_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "F",
-              "series": "measure.elasticsearch_cpu"
+              "target": "alias(measure.elasticsearch_cpu, 'elasticsearch')"
             },
             {
-              "alias": "nsqd",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.nsqd_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "G",
-              "series": "measure.nsqd_cpu"
+              "target": "alias(measure.nsqd_cpu, 'nsqd')"
             },
             {
-              "alias": "NME",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.nme_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "H",
-              "series": "measure.nme_cpu"
+              "target": "alias(measure.nme_cpu, 'nme')"
             },
             {
-              "alias": "npee",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.npee_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "I",
-              "series": "measure.npee_cpu"
+              "target": "alias(measure.npee_cpu, 'npee')"
             },
             {
-              "alias": "redis",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.redis_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "J",
-              "series": "measure.redis_cpu"
+              "target": "alias(measure.redis_cpu, 'redis')"
             },
             {
-              "alias": "rabbit",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.rabbit_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "K",
-              "series": "measure.rabbit_cpu"
+              "target": "alias(measure.rabbit_cpu, 'rabbit')"
             },
             {
-              "alias": "statsdaemon",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.statsdaemon_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "L",
-              "series": "measure.statsdaemon_cpu"
+              "target": "alias(measure.statsdaemon_cpu, 'statsdaemon')"
             },
             {
-              "alias": "coll-1",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.collector.1_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "M",
-              "series": "measure.statsdaemon_cpu"
+              "target": "alias(measure.collector.1_cpu, 'coll-1')"
             },
             {
-              "alias": "coll-2",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.collector.2_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "N",
-              "series": "measure.statsdaemon_cpu"
+              "target": "alias(measure.collector.2_cpu, 'coll-2')"
             },
             {
-              "alias": "coll-3",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.collector.3_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "O",
-              "series": "measure.statsdaemon_cpu"
+              "target": "alias(measure.collector.3_cpu, 'coll-3')"
             }
           ],
           "timeFrom": null,
@@ -213,7 +139,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -253,157 +179,8 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "1",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.1_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "A",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "2",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.2_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "B",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "3",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.3_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "C",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "4",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.4_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "D",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "5",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.5_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "E",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "6",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.6_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "F",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "7",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.7_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "G",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "8",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.8_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "H",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "9",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.9_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "I",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "10",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.10_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "J",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "11",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.11_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "K",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "12",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.12_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "L",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "13",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.13_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "M",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "14",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.14_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "N",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "15",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.15_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "O",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "16",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.16_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "P",
-              "series": "measure.cassandra_cpu"
-            },
-            {
-              "alias": "17",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.17_cpu\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "Q",
-              "series": "measure.cassandra_cpu"
+              "target": "aliasSub(measure.graphite-api.*_cpu, '.*\\.(.*)_cpu', '\\1')"
             }
           ],
           "timeFrom": null,
@@ -437,7 +214,7 @@
             "grafana": "#511749"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -477,138 +254,64 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "grafana",
-              "column": "value",
-              "query": "select mean(value) from \"measure.grafana_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "A",
-              "series": "measure.grafana_cpu",
-              "target": ""
+              "target": "alias(measure.grafana_rss, 'grafana')"
             },
             {
-              "alias": "cassandra",
-              "column": "value",
-              "query": "select mean(value) from \"measure.cassandra_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "B",
-              "series": "measure.cassandra_cpu"
+              "target": "alias(measure.cassandra_rss, 'cassandra')"
             },
             {
-              "alias": "kairosdb",
-              "column": "value",
-              "hide": true,
-              "query": "select mean(value) from \"measure.kairosdb_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "C",
-              "series": "measure.cassandra_cpu"
+              "target": "alias(measure.kairosdb_rss, 'kairosdb')"
             },
             {
-              "alias": "NMT",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.nmt_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "D",
-              "series": "measure.cassandra_cpu"
+              "target": "alias(measure.nmt_rss, 'nmt')"
             },
             {
-              "alias": "NMK",
-              "column": "value",
-              "hide": true,
-              "query": "select mean(value) from \"measure.nmk_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "E",
-              "series": "measure.cassandra_cpu"
+              "target": "alias(measure.nmk_rss, 'nmk')"
             },
             {
-              "alias": "elasticsearch",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.elasticsearch_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "F",
-              "series": "measure.elasticsearch_rss"
+              "target": "alias(measure.elasticsearch_rss, 'elasticsearch')"
             },
             {
-              "alias": "nsqd",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.nsqd_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "G",
-              "series": "measure.nsqd_rss"
+              "target": "alias(measure.nsqd_rss, 'nsqd')"
             },
             {
-              "alias": "NME",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.nme_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "H",
-              "series": "measure.nme_rss"
+              "target": "alias(measure.nme_rss, 'nme')"
             },
             {
-              "alias": "npee",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.npee_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "I",
-              "series": "measure.npee_rss"
+              "target": "alias(measure.npee_rss, 'npee')"
             },
             {
-              "alias": "redis",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.redis_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "J",
-              "series": "measure.redis_rss"
+              "target": "alias(measure.redis_rss, 'redis')"
             },
             {
-              "alias": "rabbit",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.rabbit_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "K",
-              "series": "measure.rabbit_rss"
+              "target": "alias(measure.rabbit_rss, 'rabbit')"
             },
             {
-              "alias": "statsdaemon",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.statsdaemon_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "L",
-              "series": "measure.statsdaemon_rss"
+              "target": "alias(measure.statsdaemon_rss, 'statsdaemon')"
             },
             {
-              "alias": "coll-1",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.collector.1_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "M",
-              "series": "measure.statsdaemon_rss"
+              "target": "alias(measure.collector.1_rss, 'coll-1')"
             },
             {
-              "alias": "coll-2",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.collector.2_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "N",
-              "series": "measure.statsdaemon_rss"
+              "target": "alias(measure.collector.2_rss, 'coll-2')"
             },
             {
-              "alias": "coll-3",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.collector.3_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "O",
-              "series": "measure.statsdaemon_rss"
+              "target": "alias(measure.collector.3_rss, 'coll-3')"
             }
           ],
           "timeFrom": null,
@@ -629,7 +332,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -669,157 +372,8 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "1",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.1_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "A",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "2",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.2_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "B",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "3",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.3_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "C",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "4",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.4_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "D",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "5",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.5_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "E",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "6",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.6_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "F",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "7",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.7_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "G",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "8",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.8_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "H",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "9",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.9_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "I",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "10",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.10_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "J",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "11",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.11_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "K",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "12",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.12_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "L",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "13",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.13_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "M",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "14",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.14_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "N",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "15",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.15_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "O",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "16",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.16_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "P",
-              "series": "measure.cassandra_rss"
-            },
-            {
-              "alias": "17",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"measure.graphite-api.17_rss\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
-              "refId": "Q",
-              "series": "measure.cassandra_rss"
+              "target": "aliasSub(measure.graphite-api.*_rss, '.*\\.(.*)_rss', '\\1')"
             }
           ],
           "timeFrom": null,
@@ -852,7 +406,7 @@
             "num metrics in ES": "#0A437C"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -905,43 +459,20 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "lag max",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"graphite-watcher.lag.upper\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "A",
-              "series": "graphite-watcher.lag.upper",
-              "target": ""
+              "target": "alias(graphite-watcher.lag.upper, 'lag max')"
             },
             {
-              "alias": "lag p99",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"graphite-watcher.lag.upper_99\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "B",
-              "series": "graphite-watcher.lag.upper",
-              "target": ""
+              "target": "alias(graphite-watcher.lag.upper_90, 'lag p90')"
             },
             {
-              "alias": "lag mean",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"graphite-watcher.lag.mean\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "C",
-              "series": "graphite-watcher.lag.mean",
-              "target": ""
+              "target": "alias(graphite-watcher.lag.mean, 'lag mean')"
             },
             {
-              "alias": "num metrics in ES",
-              "column": "value",
-              "hide": false,
-              "query": "select last(value) from \"graphite-watcher.num_metrics\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "D",
-              "series": "graphite-watcher.num_metrics"
+              "target": "alias(graphite-watcher.num_metrics, 'num metrics in ES')"
             }
           ],
           "timeFrom": null,
@@ -967,7 +498,7 @@
             "num metrics in ES": "#0A437C"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -1011,15 +542,8 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "null_points",
-              "column": "value",
-              "hide": false,
-              "query": "select derivative(value) from \"graphite-watcher.null_points.counter\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "A",
-              "series": "graphite-watcher.null_points.counter",
-              "target": "",
-              "interval": "20s"
+              "target": "alias(graphite-watcher.null_points.counter, 'null points')"
             }
           ],
           "timeFrom": null,
@@ -1056,7 +580,7 @@
             "unmarshal raintank resp p90": "#508642"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -1101,34 +625,16 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "raintank_query mean",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"stats.timers.graphite-api.fetch.raintank_query.query_duration.mean\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "A",
-              "series": "stats.timers.graphite-api.fetch.raintank_query.query_duration.mean",
-              "target": ""
+              "target": "alias(stats.timers.graphite-api.fetch.raintank_query.query_duration.mean, 'raintank_query mean')"
             },
             {
-              "alias": "unmarshal raintank resp mean",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"stats.timers.graphite-api.fetch.unmarshal_raintank_resp.duration.mean\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "B",
-              "series": "stats.timers.graphite-api.fetch.raintank_query.query_duration.mean",
-              "target": ""
+              "target": "alias(stats.timers.graphite-api.fetch.unmarshal_raintank_resp.duration.mean, 'unmarshal raintank resp mean')"
             },
             {
-              "alias": "search ES mean",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"stats.timers.graphite-api.search_series.es_search.query_duration.mean\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "C",
-              "series": "stats.timers.graphite-api.fetch.raintank_query.query_duration.mean",
-              "target": ""
+              "target": "alias(stats.timers.graphite-api.search_series.es_search.query_duration.mean, 'search ES mean')"
             }
           ],
           "timeFrom": null,
@@ -1157,7 +663,7 @@
             "unmarshal raintank resp p90": "#508642"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -1197,34 +703,16 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "raintank_query p90",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"stats.timers.graphite-api.fetch.raintank_query.query_duration.upper_90\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "D",
-              "series": "stats.timers.graphite-api.fetch.raintank_query.query_duration.mean",
-              "target": ""
+              "target": "alias(stats.timers.graphite-api.fetch.raintank_query.query_duration.upper_90, 'raintank_query p90')"
             },
             {
-              "alias": "unmarshal raintank resp p90",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"stats.timers.graphite-api.fetch.unmarshal_raintank_resp.duration.upper_90\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "E",
-              "series": "stats.timers.graphite-api.fetch.raintank_query.query_duration.mean",
-              "target": ""
+              "target": "alias(stats.timers.graphite-api.fetch.unmarshal_raintank_resp.duration.upper_90, 'unmarshal raintank resp p90')"
             },
             {
-              "alias": "search ES p90",
-              "column": "value",
-              "hide": false,
-              "query": "select mean(value) from \"stats.timers.graphite-api.search_series.es_search.query_duration.upper_90\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "F",
-              "series": "stats.timers.graphite-api.fetch.raintank_query.query_duration.mean",
-              "target": ""
+              "target": "alias(stats.timers.graphite-api.search_series.es_search.query_duration.upper_90, 'search ES ps90')"
             }
           ],
           "timeFrom": null,
@@ -1254,7 +742,7 @@
             "unmarshal raintank resp p90": "#508642"
           },
           "bars": false,
-          "datasource": "influxdb",
+          "datasource": "graphite",
           "editable": true,
           "error": false,
           "fill": 7,
@@ -1299,37 +787,16 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "raintank_query",
-              "column": "value",
-              "hide": false,
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.timers.graphite-api.fetch.raintank_query.query_duration.count_ps\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "A",
-              "series": "stats.timers.graphite-api.fetch.raintank_query.query_duration.mean",
-              "target": ""
+              "target": "alias(stats.timers.graphite-api.fetch.raintank_query.query_duration.count_ps, 'raintank query')"
             },
             {
-              "alias": "unmarshal raintank resp",
-              "column": "value",
-              "hide": false,
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.timers.graphite-api.fetch.unmarshal_raintank_resp.duration.count_ps\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "B",
-              "series": "stats.timers.graphite-api.fetch.raintank_query.query_duration.mean",
-              "target": ""
+              "target": "alias(stats.timers.graphite-api.fetch.unmarshal_raintank_resp.duration.count_ps, 'unmarshal raintank resp')"
             },
             {
-              "alias": "search ES",
-              "column": "value",
-              "hide": false,
-              "interval": "1s",
-              "query": "select mean(value) from \"stats.timers.graphite-api.search_series.es_search.query_duration.count_ps\" where $timeFilter group by time($interval) order asc",
-              "rawQuery": true,
               "refId": "C",
-              "series": "stats.timers.graphite-api.fetch.raintank_query.query_duration.mean",
-              "target": ""
+              "target": "alias(stats.timers.graphite-api.search_series.es_search.query_duration.count_ps, 'search ES')"
             }
           ],
           "timeFrom": null,

--- a/grafana-dev/dashboards/sys.json
+++ b/grafana-dev/dashboards/sys.json
@@ -460,19 +460,19 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(graphite-watcher.lag.upper, 'lag max')"
+              "target": "alias(graphite-watcher.$environment.lag.upper, 'lag max')"
             },
             {
               "refId": "B",
-              "target": "alias(graphite-watcher.lag.upper_90, 'lag p90')"
+              "target": "alias(graphite-watcher.$environment.lag.upper_90, 'lag p90')"
             },
             {
               "refId": "C",
-              "target": "alias(graphite-watcher.lag.mean, 'lag mean')"
+              "target": "alias(graphite-watcher.$environment.lag.mean, 'lag mean')"
             },
             {
               "refId": "D",
-              "target": "alias(graphite-watcher.num_metrics, 'num metrics in ES')"
+              "target": "alias(graphite-watcher.$environment.num_metrics, 'num metrics in ES')"
             }
           ],
           "timeFrom": null,
@@ -543,7 +543,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(graphite-watcher.null_points.counter, 'null points')"
+              "target": "alias(graphite-watcher.$environment.null_points.counter, 'null points')"
             }
           ],
           "timeFrom": null,

--- a/graphite/Dockerfile
+++ b/graphite/Dockerfile
@@ -1,0 +1,2 @@
+FROM hopsoft/graphite-statsd
+RUN rm -rf /etc/service/statsd/

--- a/graphite/Dockerfile
+++ b/graphite/Dockerfile
@@ -1,2 +1,3 @@
 FROM hopsoft/graphite-statsd
 RUN rm -rf /etc/service/statsd/
+ADD storage-schemas.conf /opt/graphite/conf/storage-schemas.conf

--- a/graphite/storage-schemas.conf
+++ b/graphite/storage-schemas.conf
@@ -1,0 +1,3 @@
+[default]
+pattern = .*
+retentions = 1s:6d

--- a/launch_dev.sh
+++ b/launch_dev.sh
@@ -21,7 +21,7 @@ echo "cleaning logs..."
 rm -rf logs/*
 
 echo "docker-compose bringing up containers..."
-docker-compose -f fig-dev.yaml up -d
+docker-compose -f fig-dev.yaml up -d || exit $?
 
 echo "starting screen session..."
 screen -S raintank -d -m -t shell bash

--- a/screens/grafana
+++ b/screens/grafana
@@ -1,5 +1,5 @@
-/tmp/create-influxdb-dev-datasource.sh &> /var/log/raintank/create-influxdb-datasource.log
+/tmp/create-dev-datasource.sh &> /var/log/raintank/create-dev-datasource.log
 /tmp/prepare-nsqd.sh &> /var/log/raintank/prepare-nsqd.log
 touch /var/log/raintank/grafana-dev.log
-cat /var/log/raintank/create-influxdb-datasource.log
+cat /var/log/raintank/create-dev-datasource.log
 tail -10f /var/log/raintank/grafana-dev.log

--- a/screens/graphiteWatcher
+++ b/screens/graphiteWatcher
@@ -1,4 +1,5 @@
 touch /var/log/raintank/graphite-watcher.log
 cd /go/src/github.com/raintank/raintank-metric/graphite-watcher
-/wait.sh elasticsearch:9200 influxdb:2003 graphite-api:8888 && ./graphite-watcher elasticsearch:9200 influxdb:2003 graphite-api:8888 &> /var/log/raintank/graphite-watcher.log &
+/wait.sh elasticsearch:9200 graphitemon:2003 graphite-api:8888
+./graphite-watcher elasticsearch:9200 graphitemon:2003 graphite-api:8888 debug &> /var/log/raintank/graphite-watcher.log &
 tail -f /var/log/raintank/graphite-watcher.log

--- a/screens/graphiteWatcher
+++ b/screens/graphiteWatcher
@@ -1,5 +1,5 @@
 touch /var/log/raintank/graphite-watcher.log
 cd /go/src/github.com/raintank/raintank-metric/graphite-watcher
 /wait.sh elasticsearch:9200 graphitemon:2003 graphite-api:8888
-./graphite-watcher elasticsearch:9200 graphitemon:2003 graphite-api:8888 debug &> /var/log/raintank/graphite-watcher.log &
+./graphite-watcher raintank-docker elasticsearch:9200 graphitemon:2003 graphite-api:8888 debug &> /var/log/raintank/graphite-watcher.log &
 tail -f /var/log/raintank/graphite-watcher.log

--- a/statsdaemon/conf/statsdaemon.ini
+++ b/statsdaemon/conf/statsdaemon.ini
@@ -1,7 +1,7 @@
 listen_addr = ":8125"
 admin_addr = ":8126"
 profile_addr = ":6060" # make "" to disable
-graphite_addr = "influxdb:2003"
+graphite_addr = "graphitemon:2003"
 flush_interval = 1
 processes = 1
 

--- a/statsdaemon/conf/statsdaemon.ini
+++ b/statsdaemon/conf/statsdaemon.ini
@@ -10,12 +10,12 @@ processes = 1
 # if this value is or expands to an empty string, it will be set to 'null'
 # supported variables:
 #  ${HOST} : hostname
-instance = "raintank-devstack"
+instance = "raintank-docker"
 
 # prefixes for the various types.  they should probably end with a dot.
-prefix_rates = "stats."
-prefix_timers = "stats.timers."
-prefix_gauges = "stats.gauges."
+prefix_rates = "stats.raintank-docker."
+prefix_timers = "stats.raintank-docker.timers."
+prefix_gauges = "stats.raintank-docker.gauges."
 
 percentile_thresholds = "90,75"
 max_timers_per_s = 1000


### PR DESCRIPTION
the sys dashboard is switched as well, still need to do the other dashboards.
the goal is for the dashboards to ultimately compatible with dev/prod stacks, so we can use the same dashboards through the entire local dev -> gce dev -> gce prod flow.
