### PR TITLE
deprecate nsq_metrics_to_elasticsearch

### DIFF
--- a/fig-dev.yaml
+++ b/fig-dev.yaml
@@ -73,20 +73,6 @@ nsqMetricsToStdout:
   volumes:
     - ./raintank_code/raintank-metric:/go/src/github.com/raintank/raintank-metric
 
-nsqMetricsToElasticsearch:
-  image: raintank/nsq_metrics_to_elasticsearch
-  hostname: nme
-  ports:
-    - "6061:6060"
-  links:
-    - nsqd:nsqd
-    - redis:redis
-    - elasticsearch:elasticsearch
-    - statsdaemon:statsdaemon
-  volumes:
-    - ./logs:/var/log/raintank
-    - ./raintank_code/raintank-metric:/go/src/github.com/raintank/raintank-metric
-
 nsqProbeEventsToElasticsearch:
   image: raintank/nsq_probe_events_to_elasticsearch
   hostname: npee

--- a/grafana-dev/dashboards/alerting.json
+++ b/grafana-dev/dashboards/alerting.json
@@ -61,16 +61,16 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-tickqueue.items.mean, 'tickqueue items')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-tickqueue.items.mean, 'tickqueue items')"
             },
             {
-              "target": "alias(stats.$environment.gauges.grafana.dev.alert-tickqueue.size, 'tickqueue size')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.gauges.grafana.dev.alert-tickqueue.size, 'tickqueue size')"
             },
             {
-              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.ticks-skipped-due-to-slow-tickqueue, 'skipped')",
-              "refId": "C"
+              "refId": "C",
+              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.ticks-skipped-due-to-slow-tickqueue, 'skipped')"
             }
           ],
           "timeFrom": null,
@@ -151,8 +151,8 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "stats.$environment.grafana.dev.alert-dispatcher.num-getschedules",
-              "refId": "A"
+              "refId": "A",
+              "target": "stats.$environment.grafana.dev.alert-dispatcher.num-getschedules"
             }
           ],
           "timeFrom": null,
@@ -213,12 +213,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-dispatcher.get-schedules.median, 'median')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-dispatcher.get-schedules.median, 'median')"
             },
             {
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-dispatcher.get-schedules.upper, 'upper')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-dispatcher.get-schedules.upper, 'upper')"
             }
           ],
           "timeFrom": null,
@@ -279,12 +279,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.job-schedules-seen, 'schedules seen per second')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.job-schedules-seen, 'schedules seen per second')"
             },
             {
-              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.jobs-scheduled, 'jobs scheduled per second')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.jobs-scheduled, 'jobs scheduled per second')"
             }
           ],
           "timeFrom": null,
@@ -367,8 +367,8 @@
               "series": "alias(stats.$environment.gauges.grafana.dev.alert-jobqueue-preamqp.size, 'size')"
             },
             {
-              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-preamqp-jobqueue, 'skipped')",
-              "refId": "C"
+              "refId": "C",
+              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-preamqp-jobqueue, 'skipped')"
             }
           ],
           "timeFrom": null,
@@ -437,16 +437,16 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.$environment.gauges.grafana.dev.alert-jobqueue-internal.items, 'items')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.gauges.grafana.dev.alert-jobqueue-internal.items, 'items')"
             },
             {
-              "target": "alias(stats.$environment.gauges.grafana.dev.alert-jobqueue-internal.size, 'size')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.gauges.grafana.dev.alert-jobqueue-internal.size, 'size')"
             },
             {
-              "target": "stats.$environment.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-internal-jobqueue, 'skipped')",
-              "refId": "C"
+              "refId": "C",
+              "target": "stats.$environment.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-internal-jobqueue, 'skipped')"
             }
           ],
           "timeFrom": null,
@@ -530,12 +530,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.$environment.grafana.dev.alert-executor.original-todo, 'query')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.grafana.dev.alert-executor.original-todo, 'query')"
             },
             {
-              "target": "alias(stats.$environment.grafana.dev.alert-executor.already-done, 'already done')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.grafana.dev.alert-executor.already-done, 'already done')"
             }
           ],
           "timeFrom": null,
@@ -614,24 +614,24 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_parse-and-evaluate.mean, 'parse evaluate mean')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_parse-and-evaluate.mean, 'parse evaluate mean')"
             },
             {
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_parse-and-evaluate.upper, 'parse-evaluate upper')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_parse-and-evaluate.upper, 'parse-evaluate upper')"
             },
             {
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_query_graphite.mean, 'query-graphite mean')",
-              "refId": "C"
+              "refId": "C",
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_query_graphite.mean, 'query-graphite mean')"
             },
             {
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_query_graphite.upper, 'query-graphite upper')",
-              "refId": "D"
+              "refId": "D",
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_query_graphite.upper, 'query-graphite upper')"
             },
             {
-              "target": "alias(sum(stats.$environment.gauges.grafana.dev.alert-executor.*num), 'num executors')",
-              "refId": "E"
+              "refId": "E",
+              "target": "alias(sum(stats.$environment.gauges.grafana.dev.alert-executor.*num), 'num executors')"
             }
           ],
           "timeFrom": null,
@@ -707,16 +707,16 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "aliasByNode(stats.$environment.grafana.dev.alert-executor.alert-outcomes.*,6)",
-              "refId": "A"
+              "refId": "A",
+              "target": "aliasByNode(stats.$environment.grafana.dev.alert-executor.alert-outcomes.*,6)"
             },
             {
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.graphite-missingVals.sum, 'missing-values')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.graphite-missingVals.sum, 'missing-values')"
             },
             {
-              "target": "alias(stats.$environment.grafana.dev.alert-executor.graphite-emptyresponse, 'empty-response')",
-              "refId": "C"
+              "refId": "C",
+              "target": "alias(stats.$environment.grafana.dev.alert-executor.graphite-emptyresponse, 'empty-response')"
             },
             {
               "query": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_execution_delay.mean, 'execution delay mean')"
@@ -782,9 +782,15 @@
   "templating": {
     "list": [
       {
-        "type": "query",
+        "allFormat": "glob",
+        "current": {
+          "text": "raintank-docker",
+          "value": "raintank-docker"
+        },
         "datasource": "graphite",
-        "refresh_on_load": false,
+        "includeAll": false,
+        "multi": false,
+        "multiFormat": "glob",
         "name": "environment",
         "options": [
           {
@@ -793,16 +799,10 @@
             "selected": true
           }
         ],
-        "includeAll": false,
-        "allFormat": "glob",
-        "multi": false,
-        "multiFormat": "glob",
         "query": "stats.*",
-        "current": {
-          "text": "raintank-docker",
-          "value": "raintank-docker",
-          "tags": []
-        }
+        "refresh": true,
+        "refresh_on_load": false,
+        "type": "query"
       }
     ]
   },

--- a/grafana-dev/dashboards/alerting.json
+++ b/grafana-dev/dashboards/alerting.json
@@ -87,7 +87,7 @@
             },
             {
               "refId": "C",
-              "target": "aliasSub(stats.$environment.grafana.*.alert-dispatcher.ticks-skipped-due-to-slow-tickqueue, '.*\\.grafana\\.([^\\.]+)\\..*', '\\1 skipped due to slow')"
+              "target": "aliasSub(stats.$environment.grafana.*.alert-dispatcher.ticks-skipped-due-to-slow-tickqueue, '.*\\.grafana\\.([^\\.]+)\\..*', '\\1 skipped')"
             }
           ],
           "timeFrom": null,
@@ -396,15 +396,15 @@
           "targets": [
             {
               "refId": "A",
-              "series": "alias(stats.$environment.gauges.grafana.*.alert-jobqueue-preamqp.items, 'items')"
+              "target": "aliasSub(stats.$environment.gauges.grafana.*.alert-jobqueue-preamqp.items, '.*gauges.grafana.([^\\.]+)\\..*', '\\1 items')"
             },
             {
               "refId": "B",
-              "series": "alias(stats.$environment.gauges.grafana.*.alert-jobqueue-preamqp.size, 'size')"
+              "target": "aliasSub(stats.$environment.gauges.grafana.*.alert-jobqueue-preamqp.size, '.*gauges.grafana.([^\\.]+)\\..*', '\\1 size')"
             },
             {
               "refId": "C",
-              "target": "alias(stats.$environment.grafana.*.alert-dispatcher.jobs-skipped-due-to-slow-preamqp-jobqueue, 'skipped')"
+              "target": "aliasSub(stats.$environment.grafana.*.alert-dispatcher.jobs-skipped-due-to-slow-preamqp-jobqueue, '.*\\.grafana\\.([^\\.]+)\\..*', '\\1 skipped')"
             }
           ],
           "timeFrom": null,
@@ -474,15 +474,15 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.gauges.grafana.*.alert-jobqueue-internal.items, 'items')"
+              "target": "aliasSub(stats.$environment.gauges.grafana.*.alert-jobqueue-internal.items, '.*gauges.grafana.([^\\.]+)\\..*', '\\1 items')"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.gauges.grafana.*.alert-jobqueue-internal.size, 'size')"
+              "target": "aliasSub(stats.$environment.gauges.grafana.*.alert-jobqueue-internal.size, '.*gauges.grafana.([^\\.]+)\\..*', '\\1 size')"
             },
             {
               "refId": "C",
-              "target": "stats.$environment.grafana.*.alert-dispatcher.jobs-skipped-due-to-slow-internal-jobqueue, 'skipped')"
+              "target": "aliasSub(stats.$environment.grafana.*.alert-dispatcher.jobs-skipped-due-to-slow-internal-jobqueue, '.*\\.grafana\\.([^\\.]+)\\..*', '\\1 skipped')"
             }
           ],
           "timeFrom": null,

--- a/grafana-dev/dashboards/alerting.json
+++ b/grafana-dev/dashboards/alerting.json
@@ -386,8 +386,19 @@
           "renderer": "flot",
           "seriesOverrides": [
             {
-              "alias": "size",
-              "color": "#E24D42"
+              "alias": "/size/",
+              "color": "#705DA0",
+              "fill": 2,
+              "linewidth": 0
+            },
+            {
+              "alias": "/skipped/",
+              "color": "#890F02",
+              "points": true
+            },
+            {
+              "alias": "/items/",
+              "color": "#E5AC0E"
             }
           ],
           "span": 4.00421052631579,
@@ -464,8 +475,19 @@
           "renderer": "flot",
           "seriesOverrides": [
             {
-              "alias": "size",
-              "color": "#E24D42"
+              "alias": "/size/",
+              "color": "#705DA0",
+              "fill": 2,
+              "linewidth": 0
+            },
+            {
+              "alias": "/skipped/",
+              "color": "#890F02",
+              "points": true
+            },
+            {
+              "alias": "/items/",
+              "color": "#E5AC0E"
             }
           ],
           "span": 3.996420641447368,

--- a/grafana-dev/dashboards/alerting.json
+++ b/grafana-dev/dashboards/alerting.json
@@ -55,22 +55,39 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "/size/",
+              "color": "#705DA0",
+              "fill": 2,
+              "linewidth": 0
+            },
+            {
+              "alias": "/skipped/",
+              "color": "#890F02",
+              "points": true
+            },
+            {
+              "alias": "/items/",
+              "color": "#E5AC0E"
+            }
+          ],
           "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
+              "hide": false,
               "refId": "A",
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-tickqueue.items.mean, 'tickqueue items')"
+              "target": "aliasSub(stats.$environment.timers.grafana.*.alert-tickqueue.items.mean, '.*timers.grafana.([^\\.]+)\\..*', '\\1 items')"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.gauges.grafana.dev.alert-tickqueue.size, 'tickqueue size')"
+              "target": "aliasSub(stats.$environment.gauges.grafana.*.alert-tickqueue.size, '.*gauges.grafana.([^\\.]+)\\..*', '\\1 size')"
             },
             {
               "refId": "C",
-              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.ticks-skipped-due-to-slow-tickqueue, 'skipped')"
+              "target": "aliasSub(stats.$environment.grafana.*.alert-dispatcher.ticks-skipped-due-to-slow-tickqueue, '.*\\.grafana\\.([^\\.]+)\\..*', '\\1 skipped due to slow')"
             }
           ],
           "timeFrom": null,
@@ -152,7 +169,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "stats.$environment.grafana.dev.alert-dispatcher.num-getschedules"
+              "target": "aliasByNode(stats.$environment.grafana.*.alert-dispatcher.num-getschedules, 3)"
             }
           ],
           "timeFrom": null,
@@ -199,26 +216,35 @@
             "total": false,
             "values": false
           },
-          "lines": true,
+          "lines": false,
           "linewidth": 2,
           "links": [],
           "nullPointMode": "null",
           "percentage": false,
-          "pointradius": 5,
-          "points": false,
+          "pointradius": 1,
+          "points": true,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "/median/",
+              "color": "#052B51"
+            },
+            {
+              "alias": "/upper/",
+              "color": "#99440A"
+            }
+          ],
           "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-dispatcher.get-schedules.median, 'median')"
+              "target": "aliasByNode(stats.$environment.timers.grafana.*.alert-dispatcher.get-schedules.median, 4, 7)"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-dispatcher.get-schedules.upper, 'upper')"
+              "target": "aliasByNode(stats.$environment.timers.grafana.*.alert-dispatcher.get-schedules.upper, 4, 7)"
             }
           ],
           "timeFrom": null,
@@ -265,26 +291,34 @@
             "total": false,
             "values": false
           },
-          "lines": true,
+          "lines": false,
           "linewidth": 2,
           "links": [],
           "nullPointMode": "null as zero",
           "percentage": false,
-          "pointradius": 5,
-          "points": false,
+          "pointradius": 3,
+          "points": true,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "/seen/",
+              "fill": 2,
+              "lines": true,
+              "linewidth": 0,
+              "points": false
+            }
+          ],
           "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.job-schedules-seen, 'schedules seen per second')"
+              "target": "aliasByNode(stats.$environment.grafana.*.alert-dispatcher.job-schedules-seen, 3, 5)"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.jobs-scheduled, 'jobs scheduled per second')"
+              "target": "aliasByNode(stats.$environment.grafana.*.alert-dispatcher.jobs-scheduled, 3, 5)"
             }
           ],
           "timeFrom": null,
@@ -298,7 +332,7 @@
           "x-axis": true,
           "y-axis": true,
           "y_formats": [
-            "short",
+            "hertz",
             "short"
           ]
         }
@@ -361,14 +395,16 @@
           "steppedLine": false,
           "targets": [
             {
-              "series": "alias(stats.$environment.gauges.grafana.dev.alert-jobqueue-preamqp.items, 'items')"
+              "refId": "A",
+              "series": "alias(stats.$environment.gauges.grafana.*.alert-jobqueue-preamqp.items, 'items')"
             },
             {
-              "series": "alias(stats.$environment.gauges.grafana.dev.alert-jobqueue-preamqp.size, 'size')"
+              "refId": "B",
+              "series": "alias(stats.$environment.gauges.grafana.*.alert-jobqueue-preamqp.size, 'size')"
             },
             {
               "refId": "C",
-              "target": "alias(stats.$environment.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-preamqp-jobqueue, 'skipped')"
+              "target": "alias(stats.$environment.grafana.*.alert-dispatcher.jobs-skipped-due-to-slow-preamqp-jobqueue, 'skipped')"
             }
           ],
           "timeFrom": null,
@@ -438,15 +474,15 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.gauges.grafana.dev.alert-jobqueue-internal.items, 'items')"
+              "target": "alias(stats.$environment.gauges.grafana.*.alert-jobqueue-internal.items, 'items')"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.gauges.grafana.dev.alert-jobqueue-internal.size, 'size')"
+              "target": "alias(stats.$environment.gauges.grafana.*.alert-jobqueue-internal.size, 'size')"
             },
             {
               "refId": "C",
-              "target": "stats.$environment.grafana.dev.alert-dispatcher.jobs-skipped-due-to-slow-internal-jobqueue, 'skipped')"
+              "target": "stats.$environment.grafana.*.alert-dispatcher.jobs-skipped-due-to-slow-internal-jobqueue, 'skipped')"
             }
           ],
           "timeFrom": null,
@@ -531,11 +567,11 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.grafana.dev.alert-executor.original-todo, 'query')"
+              "target": "alias(stats.$environment.grafana.*.alert-executor.original-todo, 'query')"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.grafana.dev.alert-executor.already-done, 'already done')"
+              "target": "alias(stats.$environment.grafana.*.alert-executor.already-done, 'already done')"
             }
           ],
           "timeFrom": null,
@@ -615,23 +651,23 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_parse-and-evaluate.mean, 'parse evaluate mean')"
+              "target": "alias(stats.$environment.timers.grafana.*.alert-executor.job_parse-and-evaluate.mean, 'parse evaluate mean')"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_parse-and-evaluate.upper, 'parse-evaluate upper')"
+              "target": "alias(stats.$environment.timers.grafana.*.alert-executor.job_parse-and-evaluate.upper, 'parse-evaluate upper')"
             },
             {
               "refId": "C",
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_query_graphite.mean, 'query-graphite mean')"
+              "target": "alias(stats.$environment.timers.grafana.*.alert-executor.job_query_graphite.mean, 'query-graphite mean')"
             },
             {
               "refId": "D",
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_query_graphite.upper, 'query-graphite upper')"
+              "target": "alias(stats.$environment.timers.grafana.*.alert-executor.job_query_graphite.upper, 'query-graphite upper')"
             },
             {
               "refId": "E",
-              "target": "alias(sum(stats.$environment.gauges.grafana.dev.alert-executor.*num), 'num executors')"
+              "target": "alias(sum(stats.$environment.gauges.grafana.*.alert-executor.*num), 'num executors')"
             }
           ],
           "timeFrom": null,
@@ -708,21 +744,23 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(stats.$environment.grafana.dev.alert-executor.alert-outcomes.*,6)"
+              "target": "aliasByNode(stats.$environment.grafana.*.alert-executor.alert-outcomes.*,6)"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.timers.grafana.dev.alert-executor.graphite-missingVals.sum, 'missing-values')"
+              "target": "alias(stats.$environment.timers.grafana.*.alert-executor.graphite-missingVals.sum, 'missing-values')"
             },
             {
               "refId": "C",
-              "target": "alias(stats.$environment.grafana.dev.alert-executor.graphite-emptyresponse, 'empty-response')"
+              "target": "alias(stats.$environment.grafana.*.alert-executor.graphite-emptyresponse, 'empty-response')"
             },
             {
-              "query": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_execution_delay.mean, 'execution delay mean')"
+              "query": "alias(stats.$environment.timers.grafana.*.alert-executor.job_execution_delay.mean, 'execution delay mean')",
+              "refId": "D"
             },
             {
-              "query": "alias(stats.$environment.timers.grafana.dev.alert-executor.job_execution_delay.upper_90, 'execution delay p90')"
+              "query": "alias(stats.$environment.timers.grafana.*.alert-executor.job_execution_delay.upper_90, 'execution delay p90')",
+              "refId": "E"
             }
           ],
           "timeFrom": null,
@@ -824,7 +862,7 @@
     ]
   },
   "refresh": false,
-  "schemaVersion": 7,
-  "version": 0,
+  "schemaVersion": 8,
+  "version": 1,
   "links": []
 }

--- a/grafana-dev/dashboards/nsq-metric-tank.json
+++ b/grafana-dev/dashboards/nsq-metric-tank.json
@@ -58,7 +58,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.metric_tank.metricstank.metrics_received, 'metrics in')"
+              "target": "alias(stats.$environment.metric_tank.$host.metrics_received, 'metrics in')"
             }
           ],
           "timeFrom": null,
@@ -133,31 +133,31 @@
               "datasource": "graphite",
               "hide": true,
               "refId": "A",
-              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.bytes_alloc.incl_freed, 'alloc incl freed')"
+              "target": "alias(stats.$environment.gauges.metric_tank.$host.bytes_alloc.incl_freed, 'alloc incl freed')"
             },
             {
               "datasource": "graphite",
               "hide": false,
               "refId": "B",
-              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.bytes_alloc.not_freed, 'alloc not freed')"
+              "target": "alias(stats.$environment.gauges.metric_tank.$host.bytes_alloc.not_freed, 'alloc not freed')"
             },
             {
               "datasource": "graphite",
               "hide": false,
               "refId": "C",
-              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.bytes_sys, 'bytes_sys')"
+              "target": "alias(stats.$environment.gauges.metric_tank.$host.bytes_sys, 'bytes_sys')"
             },
             {
               "datasource": "graphite",
               "hide": true,
               "refId": "D",
-              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.metrics_active, 'metrics_active')"
+              "target": "alias(stats.$environment.gauges.metric_tank.$host.metrics_active, 'metrics_active')"
             },
             {
               "datasource": "graphite",
               "hide": true,
               "refId": "E",
-              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.total_points, 'total_points')"
+              "target": "alias(stats.$environment.gauges.metric_tank.$host.total_points, 'total_points')"
             },
             {
               "refId": "F",
@@ -241,12 +241,12 @@
             {
               "hide": false,
               "refId": "A",
-              "target": "aliasByNode(stats.$environment.gauges.metric_tank.metricstank.total_points, 5)"
+              "target": "aliasByNode(stats.$environment.gauges.metric_tank.$host.total_points, 5)"
             },
             {
               "hide": false,
               "refId": "B",
-              "target": "aliasByNode(stats.$environment.gauges.metric_tank.metricstank.metrics_active, 5)"
+              "target": "aliasByNode(stats.$environment.gauges.metric_tank.$host.metrics_active, 5)"
             }
           ],
           "timeFrom": null,
@@ -326,42 +326,42 @@
             {
               "hide": false,
               "refId": "A",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower, 'mem-cass min')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.requests_span.mem_and_cassandra.lower, 'mem-cass min')"
             },
             {
               "hide": true,
               "refId": "B",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper_90, 'mem-cass p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.requests_span.mem_and_cassandra.upper_90, 'mem-cass p90')"
             },
             {
               "hide": false,
               "refId": "C",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.median, 'mem-cass med')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.requests_span.mem_and_cassandra.median, 'mem-cass med')"
             },
             {
               "hide": false,
               "refId": "D",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper, 'mem-cass max')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.requests_span.mem_and_cassandra.upper, 'mem-cass max')"
             },
             {
               "hide": false,
               "refId": "E",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.lower, 'mem min')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.requests_span.mem.lower, 'mem min')"
             },
             {
               "hide": false,
               "refId": "F",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.median, 'mem med')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.requests_span.mem.median, 'mem med')"
             },
             {
               "hide": true,
               "refId": "G",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.upper_90, 'mem p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.requests_span.mem.upper_90, 'mem p90')"
             },
             {
               "hide": false,
               "refId": "H",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.upper, 'mem max')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.requests_span.mem.upper, 'mem max')"
             }
           ],
           "timeFrom": null,
@@ -433,12 +433,12 @@
             {
               "hide": false,
               "refId": "A",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.count_ps, 'mem-cass req/s')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.requests_span.mem_and_cassandra.count_ps, 'mem-cass req/s')"
             },
             {
               "hide": false,
               "refId": "B",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.count_ps, 'mem req/s')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.requests_span.mem.count_ps, 'mem req/s')"
             }
           ],
           "timeFrom": null,
@@ -504,15 +504,15 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.request_handle_duration.median, 'median')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.request_handle_duration.median, 'median')"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.request_handle_duration.upper_90, 'p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.request_handle_duration.upper_90, 'p90')"
             },
             {
               "refId": "C",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.request_handle_duration.upper, 'max')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.request_handle_duration.upper, 'max')"
             }
           ],
           "timeFrom": null,
@@ -589,27 +589,27 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_load.median, 'size at load median')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.chunk_size.at_load.median, 'size at load median')"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_load.upper_90, 'size at load p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.chunk_size.at_load.upper_90, 'size at load p90')"
             },
             {
               "refId": "C",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_load.upper, 'size at load max')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.chunk_size.at_load.upper, 'size at load max')"
             },
             {
               "refId": "D",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_save.median, 'size at save median')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.chunk_size.at_save.median, 'size at save median')"
             },
             {
               "refId": "E",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_save.upper_90, 'size at save p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.chunk_size.at_save.upper_90, 'size at save p90')"
             },
             {
               "refId": "F",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_save.upper, 'size at save max')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.chunk_size.at_save.upper, 'size at save max')"
             }
           ],
           "timeFrom": null,
@@ -679,11 +679,11 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_put_duration.count_ps, 'put/s')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.cassandra_put_duration.count_ps, 'put/s')"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_get_duration.count_ps, 'get/s')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.cassandra_get_duration.count_ps, 'get/s')"
             }
           ],
           "timeFrom": null,
@@ -753,19 +753,19 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_put_duration.upper_90, 'put p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.cassandra_put_duration.upper_90, 'put p90')"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_put_duration.mean, 'put mean')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.cassandra_put_duration.mean, 'put mean')"
             },
             {
               "refId": "C",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_get_duration.upper_90, 'get p90')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.cassandra_get_duration.upper_90, 'get p90')"
             },
             {
               "refId": "D",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_get_duration.mean, 'get mean')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.cassandra_get_duration.mean, 'get mean')"
             }
           ],
           "timeFrom": null,
@@ -853,27 +853,27 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.median, 'chunks per row med')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.cassandra_chunks_per_row.median, 'chunks per row med')"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.lower, 'chunks per row min')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.cassandra_chunks_per_row.lower, 'chunks per row min')"
             },
             {
               "refId": "C",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.upper, 'chunks per row max')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.cassandra_chunks_per_row.upper, 'chunks per row max')"
             },
             {
               "refId": "D",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.median, 'rows per resp med')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.cassandra_chunks_per_row.median, 'rows per resp med')"
             },
             {
               "refId": "E",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_rows_per_response.lower, 'rows per resp min')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.cassandra_rows_per_response.lower, 'rows per resp min')"
             },
             {
               "refId": "F",
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_rows_per_response.upper, 'rows per resp max')"
+              "target": "alias(stats.$environment.timers.metric_tank.$host.cassandra_rows_per_response.upper, 'rows per resp max')"
             }
           ],
           "timeFrom": null,
@@ -939,19 +939,19 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.create, 'create/s')"
+              "target": "alias(stats.$environment.metric_tank.$host.chunks.create, 'create/s')"
             },
             {
               "refId": "B",
-              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.clear, 'clear/s')"
+              "target": "alias(stats.$environment.metric_tank.$host.chunks.clear, 'clear/s')"
             },
             {
               "refId": "C",
-              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.save_ok, 'save_ok/s')"
+              "target": "alias(stats.$environment.metric_tank.$host.chunks.save_ok, 'save_ok/s')"
             },
             {
               "refId": "D",
-              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.save_fail, 'save_fail/s')"
+              "target": "alias(stats.$environment.metric_tank.$host.chunks.save_fail, 'save_fail/s')"
             }
           ],
           "timeFrom": null,
@@ -1029,15 +1029,15 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.$environment.metric_tank.metricstank.metricmeta_cache.hit, 'cache hit')"
+              "target": "alias(stats.$environment.metric_tank.$host.metricmeta_cache.hit, 'cache hit')"
             },
             {
               "refId": "B",
-              "target": "aliasSub(stats.$environment.timers.metric_tank.metricstank.metricmeta_cache_lookup_duration.{median,upper_90}, '.*duration\\.(.*)', 'duration \\1')"
+              "target": "aliasSub(stats.$environment.timers.metric_tank.$host.metricmeta_cache_lookup_duration.{median,upper_90}, '.*duration\\.(.*)', 'duration \\1')"
             },
             {
               "refId": "C",
-              "target": "alias(stats.$environment.metric_tank.metricstank.metricmeta_cache.miss, 'cache miss')"
+              "target": "alias(stats.$environment.metric_tank.$host.metricmeta_cache.miss, 'cache miss')"
             }
           ],
           "timeFrom": null,
@@ -1115,6 +1115,31 @@
           }
         ],
         "query": "stats.*",
+        "refresh": true,
+        "refresh_on_load": false,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allFormat": "glob",
+        "current": {
+          "text": "hello",
+          "value": "hello"
+        },
+        "datasource": "graphite",
+        "includeAll": false,
+        "multi": false,
+        "multiFormat": "glob",
+        "name": "host",
+        "options": [
+          {
+            "selected": true,
+            "text": "hello",
+            "value": "hello"
+          }
+        ],
+        "query": "stats.$environment.metric_tank.*",
+        "refresh": true,
         "refresh_on_load": false,
         "regex": "",
         "type": "query"

--- a/grafana-dev/dashboards/nsq-metric-tank.json
+++ b/grafana-dev/dashboards/nsq-metric-tank.json
@@ -57,8 +57,8 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.$environment.metric_tank.metricstank.metrics_received, 'metrics in')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.metric_tank.metricstank.metrics_received, 'metrics in')"
             }
           ],
           "timeFrom": null,
@@ -82,13 +82,13 @@
           "datasource": "-- Mixed --",
           "editable": true,
           "error": false,
-          "fill": 1,
+          "fill": 0,
           "grid": {
             "leftLogBase": 1,
             "leftMax": null,
-            "leftMin": null,
+            "leftMin": 0,
             "rightLogBase": 1,
-            "rightMax": null,
+            "rightMax": 100000,
             "rightMin": null,
             "threshold1": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
@@ -107,7 +107,7 @@
             "values": false
           },
           "lines": true,
-          "linewidth": 2,
+          "linewidth": 3,
           "links": [],
           "nullPointMode": "null",
           "percentage": false,
@@ -116,8 +116,13 @@
           "renderer": "flot",
           "seriesOverrides": [
             {
-              "alias": "points per metric",
+              "alias": "total_points",
               "yaxis": 2
+            },
+            {
+              "alias": "bytes_per_point",
+              "yaxis": 2,
+              "linewidth": 1
             }
           ],
           "span": 3.1112631064967107,
@@ -127,32 +132,39 @@
             {
               "datasource": "graphite",
               "hide": true,
-              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.bytes_alloc.incl_freed, 'alloc incl freed')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.bytes_alloc.incl_freed, 'alloc incl freed')"
             },
             {
               "datasource": "graphite",
               "hide": false,
-              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.bytes_alloc.not_freed, 'alloc not freed')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.bytes_alloc.not_freed, 'alloc not freed')"
             },
             {
               "datasource": "graphite",
               "hide": false,
-              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.bytes_sys, 'bytes_sys')",
-              "refId": "C"
+              "refId": "C",
+              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.bytes_sys, 'bytes_sys')"
             },
             {
               "datasource": "graphite",
-              "hide": false,
-              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.metrics_active, 'metrics_active')",
-              "refId": "D"
+              "hide": true,
+              "refId": "D",
+              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.metrics_active, 'metrics_active')"
             },
             {
               "datasource": "graphite",
-              "hide": false,
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.points_per_metric.mean, 'points per metric')",
-              "refId": "E"
+              "hide": true,
+              "refId": "E",
+              "target": "alias(stats.$environment.gauges.metric_tank.metricstank.total_points, 'total_points')"
+            },
+            {
+              "refId": "F",
+              "datasource": "graphite",
+              "target": "alias(divideSeries(#B, #E), 'bytes_per_point')",
+              "textEditor": false,
+              "hide": false
             }
           ],
           "timeFrom": null,
@@ -167,7 +179,7 @@
           "y-axis": true,
           "y_formats": [
             "bytes",
-            "short"
+            "bytes"
           ]
         },
         {
@@ -176,7 +188,8 @@
             "999th": "#890F02",
             "99th": "#99440A",
             "mean": "#0A437C",
-            "median": "#3F6833"
+            "median": "#3F6833",
+            "total_points": "#65C5DB"
           },
           "bars": false,
           "datasource": "graphite",
@@ -213,25 +226,32 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "total_points",
+              "yaxis": 2,
+              "fill": 0,
+              "linewidth": 1
+            }
+          ],
           "span": 6.019263209292763,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
               "hide": false,
-              "target": "stats.$environment.timers.metric_tank.metricstank.points_per_metric.median",
-              "refId": "A"
+              "refId": "A",
+              "target": "aliasByNode(stats.$environment.gauges.metric_tank.metricstank.total_points, 5)"
             },
             {
               "hide": false,
-              "target": "stats.$environment.timers.metric_tank.metricstank.points_per_metric.999-percentile",
-              "refId": "B"
+              "refId": "B",
+              "target": "aliasByNode(stats.$environment.gauges.metric_tank.metricstank.metrics_active, 5)"
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "points per metric",
+          "title": "points & metrics",
           "tooltip": {
             "shared": true,
             "value_type": "cumulative"
@@ -305,43 +325,43 @@
           "targets": [
             {
               "hide": false,
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower, 'mem-cass min')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.lower, 'mem-cass min')"
             },
             {
               "hide": true,
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper_90, 'mem-cass p90')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper_90, 'mem-cass p90')"
             },
             {
               "hide": false,
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.median, 'mem-cass med')",
-              "refId": "C"
+              "refId": "C",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.median, 'mem-cass med')"
             },
             {
               "hide": false,
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper, 'mem-cass max')",
-              "refId": "D"
+              "refId": "D",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.upper, 'mem-cass max')"
             },
             {
               "hide": false,
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.lower, 'mem min')",
-              "refId": "E"
+              "refId": "E",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.lower, 'mem min')"
             },
             {
               "hide": false,
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.median, 'mem med')",
-              "refId": "F"
+              "refId": "F",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.median, 'mem med')"
             },
             {
               "hide": true,
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.upper_90, 'mem p90')",
-              "refId": "G"
+              "refId": "G",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.upper_90, 'mem p90')"
             },
             {
               "hide": false,
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.upper, 'mem max')",
-              "refId": "H"
+              "refId": "H",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.upper, 'mem max')"
             }
           ],
           "timeFrom": null,
@@ -412,13 +432,13 @@
           "targets": [
             {
               "hide": false,
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.count_ps, 'mem-cass req/s')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem_and_cassandra.count_ps, 'mem-cass req/s')"
             },
             {
               "hide": false,
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.count_ps, 'mem req/s')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.requests_span.mem.count_ps, 'mem req/s')"
             }
           ],
           "timeFrom": null,
@@ -483,16 +503,16 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.request_handle_duration.median, 'median')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.request_handle_duration.median, 'median')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.request_handle_duration.upper_90, 'p90')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.request_handle_duration.upper_90, 'p90')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.request_handle_duration.upper, 'max')",
-              "refId": "C"
+              "refId": "C",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.request_handle_duration.upper, 'max')"
             }
           ],
           "timeFrom": null,
@@ -568,28 +588,28 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_load.median, 'size at load median')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_load.median, 'size at load median')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_load.upper_90, 'size at load p90')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_load.upper_90, 'size at load p90')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_load.upper, 'size at load max')",
-              "refId": "C"
+              "refId": "C",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_load.upper, 'size at load max')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_save.median, 'size at save median')",
-              "refId": "D"
+              "refId": "D",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_save.median, 'size at save median')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_save.upper_90, 'size at save p90')",
-              "refId": "E"
+              "refId": "E",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_save.upper_90, 'size at save p90')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_save.upper, 'size at save max')",
-              "refId": "F"
+              "refId": "F",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.chunk_size.at_save.upper, 'size at save max')"
             }
           ],
           "timeFrom": null,
@@ -658,12 +678,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_put_duration.count_ps, 'put/s')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_put_duration.count_ps, 'put/s')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_get_duration.count_ps, 'get/s')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_get_duration.count_ps, 'get/s')"
             }
           ],
           "timeFrom": null,
@@ -732,20 +752,20 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_put_duration.upper_90, 'put p90')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_put_duration.upper_90, 'put p90')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_put_duration.mean, 'put mean')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_put_duration.mean, 'put mean')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_get_duration.upper_90, 'get p90')",
-              "refId": "C"
+              "refId": "C",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_get_duration.upper_90, 'get p90')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_get_duration.mean, 'get mean')",
-              "refId": "D"
+              "refId": "D",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_get_duration.mean, 'get mean')"
             }
           ],
           "timeFrom": null,
@@ -832,28 +852,28 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.median, 'chunks per row med')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.median, 'chunks per row med')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.lower, 'chunks per row min')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.lower, 'chunks per row min')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.upper, 'chunks per row max')",
-              "refId": "C"
+              "refId": "C",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.upper, 'chunks per row max')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.median, 'rows per resp med')",
-              "refId": "D"
+              "refId": "D",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_chunks_per_row.median, 'rows per resp med')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_rows_per_response.lower, 'rows per resp min')",
-              "refId": "E"
+              "refId": "E",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_rows_per_response.lower, 'rows per resp min')"
             },
             {
-              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_rows_per_response.upper, 'rows per resp max')",
-              "refId": "F"
+              "refId": "F",
+              "target": "alias(stats.$environment.timers.metric_tank.metricstank.cassandra_rows_per_response.upper, 'rows per resp max')"
             }
           ],
           "timeFrom": null,
@@ -918,20 +938,20 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.create, 'create/s')",
-              "refId": "A"
+              "refId": "A",
+              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.create, 'create/s')"
             },
             {
-              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.clear, 'clear/s')",
-              "refId": "B"
+              "refId": "B",
+              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.clear, 'clear/s')"
             },
             {
-              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.save_ok, 'save_ok/s')",
-              "refId": "C"
+              "refId": "C",
+              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.save_ok, 'save_ok/s')"
             },
             {
-              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.save_fail, 'save_fail/s')",
-              "refId": "D"
+              "refId": "D",
+              "target": "alias(stats.$environment.metric_tank.metricstank.chunks.save_fail, 'save_fail/s')"
             }
           ],
           "timeFrom": null,
@@ -950,58 +970,62 @@
           ]
         },
         {
-          "title": "metric def lookups",
-          "error": false,
-          "span": 4,
-          "editable": true,
-          "type": "graph",
-          "isNew": true,
-          "id": 12,
+          "aliasColors": {
+            "cache hit": "#3F6833",
+            "duration median": "#BA43A9",
+            "duration upper_90": "#511749",
+            "metricdef lookup duration median": "#E0752D",
+            "metricdef lookup duration upper_90": "#BF1B00"
+          },
+          "bars": false,
           "datasource": "graphite",
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "short",
-            "ms"
-          ],
+          "editable": true,
+          "error": false,
+          "fill": 1,
           "grid": {
             "leftLogBase": 1,
             "leftMax": null,
-            "rightMax": null,
             "leftMin": null,
-            "rightMin": null,
             "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "lines": false,
-          "fill": 1,
-          "linewidth": 2,
-          "points": true,
-          "pointradius": 1,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
+          "id": 12,
+          "isNew": true,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
+          "lines": false,
+          "linewidth": 2,
+          "links": [],
           "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 1,
+          "points": true,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "duration upper_90",
+              "yaxis": 2
+            },
+            {
+              "alias": "duration median",
+              "yaxis": 2
+            }
+          ],
+          "span": 4,
+          "stack": false,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true
-          },
-          "timeFrom": null,
-          "timeShift": null,
           "targets": [
             {
               "refId": "A",
@@ -1016,24 +1040,20 @@
               "target": "alias(stats.$environment.metric_tank.metricstank.metricmeta_cache.miss, 'cache miss')"
             }
           ],
-          "aliasColors": {
-            "cache hit": "#3F6833",
-            "metricdef lookup duration median": "#E0752D",
-            "metricdef lookup duration upper_90": "#BF1B00",
-            "duration upper_90": "#511749",
-            "duration median": "#BA43A9"
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "metric def lookups",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
           },
-          "seriesOverrides": [
-            {
-              "alias": "duration upper_90",
-              "yaxis": 2
-            },
-            {
-              "alias": "duration median",
-              "yaxis": 2
-            }
-          ],
-          "links": []
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "ms"
+          ]
         }
       ],
       "title": "New row"

--- a/screens/metricTank
+++ b/screens/metricTank
@@ -21,6 +21,7 @@ cd /go/src/github.com/raintank/raintank-metric/metric_tank
 	--primary-node \
 	--elastic-addr elasticsearch:9200 \
 	--redis-addr redis:6379 \
+	--elastic-warmup-pct 100 \
 	--cassandra-addrs cassandra &>> /var/log/raintank/nsq_metrics_tank.log &
 tail -f /var/log/raintank/nsq_metrics_tank.log 
 

--- a/screens/nsq_metrics_to_elasticsearch
+++ b/screens/nsq_metrics_to_elasticsearch
@@ -1,4 +1,0 @@
-cd /go/src/github.com/raintank/raintank-metric/nsq_metrics_to_elasticsearch
-/wait.sh elasticsearch:9200 redis:6379
-./nsq_metrics_to_elasticsearch --elastic-addr elasticsearch:9200 --redis-addr redis:6379 --statsd-addr statsdaemon:8125 --nsqd-tcp-address nsqd:4150 &> /var/log/raintank/nsq_metrics_to_elasticsearch.log &
-tail -f /var/log/raintank/nsq_metrics_to_elasticsearch.log


### PR DESCRIPTION
that functionality has been moved into metric-tank
