### PR TITLE
Removes use of removed `-f` option in `docker tag` command

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -19,8 +19,7 @@ function build () {
 	else
 		docker build -t raintank/$service . || fail $service
 	fi
-	# -f because docker will complain if the id->name mapping already exists, which is not an issue with docker build -t
-	docker tag -f raintank/$service raintank/$service:$(git rev-parse --abbrev-ref HEAD) || fail $service
+	docker tag raintank/$service raintank/$service:$(git rev-parse --abbrev-ref HEAD) || fail $service
 	cd ..
 }
 


### PR DESCRIPTION
OS: `OSX 10.11.6`

``` bash
$ docker --version
Docker version 1.12.0, build 8eab29e
```

The `./build_all.sh` script errors:

```
...
Removing intermediate container 2cff0a33c256
Step 5 : VOLUME /var/log/raintank
 ---> Running in eab0eec9a218
 ---> 525c73885022
Removing intermediate container eab0eec9a218
Successfully built 525c73885022
unknown shorthand flag: 'f' in -f
See 'docker tag --help'.
ERROR: failed building nodejs. stopping.
```

It appears that `docker tag` no longer accepts the `-f` flag to force
the operation. References: [Docker forum](https://forums.docker.com/t/force-tag-f-option-removed/18782), [stackoverflow](http://stackoverflow.com/questions/38127037/how-to-force-a-docker-push-on-mac-osx).

This change removes the use of the `-f` flag from the `docker tag` command. It does not address [backwards compatibility](https://forums.docker.com/t/docker-1-12-breaks-docker-tag-f-in-scripts/16992) with older docker versions.
