### PR TITLE
Fixes location of the worldping_api scripts directory

### DIFF
--- a/docker/worldping_api/Dockerfile
+++ b/docker/worldping_api/Dockerfile
@@ -8,8 +8,8 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 RUN mkdir -p /go/src/github.com/raintank/
 RUN cd /go/src/github.com/raintank/ && git clone https://github.com/raintank/worldping-api.git
-RUN cd /go/src/github.com/raintank/worldping-api && ./rt-pkg/depends.sh
-RUN cd /go/src/github.com/raintank/worldping-api && ./rt-pkg/build.sh
+RUN cd /go/src/github.com/raintank/worldping-api && ./scripts/depends.sh
+RUN cd /go/src/github.com/raintank/worldping-api && ./scripts/build.sh
 RUN cd /go/src/github.com/raintank/worldping-api && go build -o /go/bin/worldping-api
 
 EXPOSE 80


### PR DESCRIPTION
OSX version: `10.11.6`

```
$ docker --version
Docker version 1.12.0, build 8eab29e
```

**Problem**
When running `/.build_all.sh`, I was getting the following error:

```
...
Step 8 : RUN cd /go/src/github.com/raintank/worldping-api &&
./rt-pkg/depends.sh
 ---> Running in 62ee2732d727
/bin/sh: 1: ./rt-pkg/depends.sh: not found
The command '/bin/sh -c cd /go/src/github.com/raintank/worldping-api &&
./rt-pkg/depends.sh' returned a non-zero code: 127
ERROR: failed building worldping_api. stopping.
```

raintank/worldping-api@0084de367c6c29c6ac69b86446ce979a4a79c338 changed the name of the scripts directory in the [worldping_api](https://github.com/raintank/worldping-api/tree/master/scripts) project from `rt-pkg` to `scripts`.

This change updates the worldping_api Dockerfile to use the new scripts directory.

Related to this is issue #70. The described error is still happening, but at different line numbers because of the previously mentioned [commit](https://github.com/raintank/worldping-api/commit/0084de367c6c29c6ac69b86446ce979a4a79c338#diff-6fc16ff3fc0d77f9d34d38202b2cc66cL23).
