### PR TITLE
metrictank clustering

### DIFF
--- a/docker/benchmark/scripts/cluster-workload-gentle.sh
+++ b/docker/benchmark/scripts/cluster-workload-gentle.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+wait.sh kafka:9092
+fakemetrics -shard-org -listen :6764 -kafka-mdm-tcp-address kafka:9092 -kafka-comp none -statsd-addr statsdaemon:8125 -orgs 2 -keys-per-org 10 &

--- a/docker/benchmark/scripts/cluster-workload-stress.sh
+++ b/docker/benchmark/scripts/cluster-workload-stress.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+wait.sh kafka:9092 cassandra:9042
+fakemetrics -shard-org -listen :6764 -kafka-mdm-tcp-address kafka:9092 -kafka-comp none -statsd-addr statsdaemon:8125 -orgs 2 -keys-per-org 10000 &
+
+echo "$(date) waiting a minute to let the data flow through into MT and into cassandra"
+sleep 60
+echo "$(date) waiting done"
+inspect-idx -addr http://metrictank0:6063 cass cassandra:9042 raintank vegeta-mt-graphite | vegeta attack -rate 10 -duration=1min | vegeta report

--- a/docker/fig-dev.yaml
+++ b/docker/fig-dev.yaml
@@ -60,12 +60,11 @@ services:
       - ../logs:/var/log/raintank
       - ../code/inspect:/go/src/github.com/raintank/inspect
 
-  metrictank:
+  metrictank0:
     image: raintank/metrictank
-    hostname: metrictank
+    hostname: metrictank0
     ports:
-      - "6063:6063"
-      - "2002:2003"
+      - "6070:6063"
     volumes:
       - ../logs:/var/log/raintank
       - ./metrictank:/etc/raintank
@@ -73,6 +72,141 @@ services:
     environment:
       WAIT_HOSTS: kafka:9092,elasticsearch:9200,toxiproxy:9042
       WAIT_TIMEOUT: 30
+      MT_KAFKA_MDM_IN_PARTITIONS : 0,1,2,3
+      MT_INSTANCE: metrictank0
+      MT_LOG_LEVEL: 1
+      MT_CLUSTER_MODE: multi
+      MT_CLUSTER_PEERS: metrictank1:6063,metrictank2:6063,metrictank3:6063,metrictank4:6063,metrictank5:6063,metrictank6:6063,metrictank7:6063
+      MT_CLUSTER_PRIMARY_NODE: "true"
+
+  metrictank1:
+    image: raintank/metrictank
+    hostname: metrictank1
+    ports:
+      - "6071:6063"
+    volumes:
+      - ../logs:/var/log/raintank
+      - ./metrictank:/etc/raintank
+      - ../code/metrictank/build/metrictank:/usr/bin/metrictank
+    environment:
+      WAIT_HOSTS: kafka:9092,elasticsearch:9200,toxiproxy:9042,metrictank0:6063
+      WAIT_TIMEOUT: 30
+      MT_KAFKA_MDM_IN_PARTITIONS : 0,1,2,3
+      MT_INSTANCE: metrictank1
+      MT_LOG_LEVEL: 1
+      MT_CLUSTER_MODE: multi
+      MT_CLUSTER_PEERS: metrictank0:6063,metrictank2:6063,metrictank3:6063,metrictank4:6063,metrictank5:6063,metrictank6:6063,metrictank7:6063
+
+  metrictank2:
+    image: raintank/metrictank
+    hostname: metrictank2
+    ports:
+      - "6072:6063"
+    volumes:
+      - ../logs:/var/log/raintank
+      - ./metrictank:/etc/raintank
+      - ../code/metrictank/build/metrictank:/usr/bin/metrictank
+    environment:
+      WAIT_HOSTS: kafka:9092,elasticsearch:9200,toxiproxy:9042,metrictank0:6063
+      WAIT_TIMEOUT: 30
+      MT_KAFKA_MDM_IN_PARTITIONS : 4,5,6,7
+      MT_INSTANCE: metrictank2
+      MT_LOG_LEVEL: 1
+      MT_CLUSTER_MODE: multi
+      MT_CLUSTER_PEERS: metrictank0:6063,metrictank1:6063,metrictank3:6063,metrictank4:6063,metrictank5:6063,metrictank6:6063,metrictank7:6063
+      MT_CLUSTER_PRIMARY_NODE: "true"
+
+  metrictank3:
+    image: raintank/metrictank
+    hostname: metrictank3
+    ports:
+      - "6073:6063"
+    volumes:
+      - ../logs:/var/log/raintank
+      - ./metrictank:/etc/raintank
+      - ../code/metrictank/build/metrictank:/usr/bin/metrictank
+    environment:
+      WAIT_HOSTS: kafka:9092,elasticsearch:9200,toxiproxy:9042,metrictank0:6063
+      WAIT_TIMEOUT: 30
+      MT_KAFKA_MDM_IN_PARTITIONS : 4,5,6,7
+      MT_INSTANCE: metrictank3
+      MT_LOG_LEVEL: 1
+      MT_CLUSTER_MODE: multi
+      MT_CLUSTER_PEERS: metrictank0:6063,metrictank1:6063,metrictank2:6063,metrictank4:6063,metrictank5:6063,metrictank6:6063,metrictank7:6063
+
+  metrictank4:
+    image: raintank/metrictank
+    hostname: metrictank4
+    ports:
+      - "6074:6063"
+    volumes:
+      - ../logs:/var/log/raintank
+      - ./metrictank:/etc/raintank
+      - ../code/metrictank/build/metrictank:/usr/bin/metrictank
+    environment:
+      WAIT_HOSTS: kafka:9092,elasticsearch:9200,toxiproxy:9042,metrictank0:6063
+      WAIT_TIMEOUT: 30
+      MT_KAFKA_MDM_IN_PARTITIONS : 8,9,10,11
+      MT_INSTANCE: metrictank4
+      MT_LOG_LEVEL: 1
+      MT_CLUSTER_MODE: multi
+      MT_CLUSTER_PEERS: metrictank0:6063,metrictank1:6063,metrictank2:6063,metrictank3:6063,metrictank5:6063,metrictank6:6063,metrictank7:6063
+      MT_CLUSTER_PRIMARY_NODE: "true"
+
+  metrictank5:
+    image: raintank/metrictank
+    hostname: metrictank5
+    ports:
+      - "6075:6063"
+    volumes:
+      - ../logs:/var/log/raintank
+      - ./metrictank:/etc/raintank
+      - ../code/metrictank/build/metrictank:/usr/bin/metrictank
+    environment:
+      WAIT_HOSTS: kafka:9092,elasticsearch:9200,toxiproxy:9042,metrictank0:6063
+      WAIT_TIMEOUT: 30
+      MT_KAFKA_MDM_IN_PARTITIONS : 8,9,10,11
+      MT_INSTANCE: metrictank5
+      MT_LOG_LEVEL: 1
+      MT_CLUSTER_MODE: multi
+      MT_CLUSTER_PEERS: metrictank0:6063,metrictank1:6063,metrictank2:6063,metrictank3:6063,metrictank4:6063,metrictank6:6063,metrictank7:6063
+
+  metrictank6:
+    image: raintank/metrictank
+    hostname: metrictank6
+    ports:
+      - "6076:6063"
+    volumes:
+      - ../logs:/var/log/raintank
+      - ./metrictank:/etc/raintank
+      - ../code/metrictank/build/metrictank:/usr/bin/metrictank
+    environment:
+      WAIT_HOSTS: kafka:9092,elasticsearch:9200,toxiproxy:9042,metrictank0:6063
+      WAIT_TIMEOUT: 30
+      MT_KAFKA_MDM_IN_PARTITIONS : 12,13,14,15
+      MT_INSTANCE: metrictank6
+      MT_LOG_LEVEL: 1
+      MT_CLUSTER_MODE: multi
+      MT_CLUSTER_PEERS: metrictank0:6063,metrictank1:6063,metrictank2:6063,metrictank3:6063,metrictank4:6063,metrictank5:6063,metrictank7:6063
+      MT_CLUSTER_PRIMARY_NODE: "true"
+
+  metrictank7:
+    image: raintank/metrictank
+    hostname: metrictank7
+    ports:
+      - "6077:6063"
+    volumes:
+      - ../logs:/var/log/raintank
+      - ./metrictank:/etc/raintank
+      - ../code/metrictank/build/metrictank:/usr/bin/metrictank
+    environment:
+      WAIT_HOSTS: kafka:9092,elasticsearch:9200,toxiproxy:9042,metrictank0:6063
+      WAIT_TIMEOUT: 30
+      MT_KAFKA_MDM_IN_PARTITIONS : 12,13,14,15
+      MT_INSTANCE: metrictank7
+      MT_LOG_LEVEL: 1
+      MT_CLUSTER_MODE: multi
+      MT_CLUSTER_PEERS: metrictank0:6063,metrictank1:6063,metrictank2:6063,metrictank3:6063,metrictank4:6063,metrictank5:6063,metrictank6:6063
 
   eventtank:
     image: raintank/eventtank
@@ -125,7 +259,7 @@ services:
     ports:
       - "8888:8888"
     environment:
-      WAIT_HOSTS: elasticsearch:9200,metrictank:6063
+      WAIT_HOSTS: elasticsearch:9200,metrictank0:6063
     volumes:
       - ../logs:/var/log/raintank
       - ./graphite-metrictank/graphite-metrictank.yaml:/etc/graphite-metrictank/graphite-metrictank.yaml
@@ -165,7 +299,7 @@ services:
       - "6764:6764"
     links:
       - graphiteMetrictank:graphite-api
-      - metrictank:metrictank
+      - metrictank0:metrictank
       - toxiproxy:toxiproxy
 
   grafana:
@@ -174,7 +308,7 @@ services:
     ports:
       - "3000:3000"
     links:
-      - metrictank:metrictank
+      - metrictank0:metrictank
       - proxy:tsdb-gw.raintank.io
       - proxy:worldping-api.raintank.io
     volumes:

--- a/docker/fig-dev.yaml
+++ b/docker/fig-dev.yaml
@@ -22,6 +22,7 @@ services:
     hostname: kafka
     environment:
       ADVERTISED_HOST: kafka
+      NUM_PARTITIONS: 16
     ports:
       - "2181:2181"
       - "9092:9092"

--- a/docker/fig-dev.yaml
+++ b/docker/fig-dev.yaml
@@ -32,6 +32,14 @@ services:
       - ../logs/zookeeper:/var/log/zookeeper
       - ../logs/supervisor:/var/log/supervisor
 
+  kafkaready:
+    image: raintank/kafkaready
+    ports:
+      - "10101"
+    environment:
+            ZOOKEEPER : kafka:2181
+
+
   kafkaManager:
     image: sheepkiller/kafka-manager
     hostname: kafka-manager
@@ -70,7 +78,7 @@ services:
       - ./metrictank:/etc/raintank
       - ../code/metrictank/build/metrictank:/usr/bin/metrictank
     environment:
-      WAIT_HOSTS: kafka:9092,elasticsearch:9200,toxiproxy:9042
+      WAIT_HOSTS: kafka:9092,elasticsearch:9200,toxiproxy:9042,kafkaready:10101
       WAIT_TIMEOUT: 30
       MT_KAFKA_MDM_IN_PARTITIONS : 0,1,2,3
       MT_INSTANCE: metrictank0

--- a/docker/grafana/dashboards/sys.json
+++ b/docker/grafana/dashboards/sys.json
@@ -61,6 +61,10 @@
             {
               "refId": "A",
               "target": "aliasByNode(measure.collector.*.cpu, 1, 2)"
+            },
+            {
+              "refId": "C",
+              "target": "aliasByNode(measure.metrictank.*.cpu, 1, 2)"
             }
           ],
           "timeFrom": null,
@@ -217,6 +221,10 @@
             {
               "refId": "A",
               "target": "aliasByNode(measure.collector.*.rss, 1, 2)"
+            },
+            {
+              "refId": "C",
+              "target": "aliasByNode(measure.metrictank.*.rss, 1, 2)"
             }
           ],
           "timeFrom": null,

--- a/docker/graphite-metrictank/graphite-metrictank.yaml
+++ b/docker/graphite-metrictank/graphite-metrictank.yaml
@@ -6,7 +6,7 @@ functions:
 - graphite_api.functions.PieFunctions
 raintank:
   tank:
-    url: http://metrictank:6063/
+    url: http://metrictank0:6063/
   cache_ttl: 60
 search_index: /var/lib/graphite/index
 time_zone: America/New_York

--- a/docker/kafkaready/Dockerfile
+++ b/docker/kafkaready/Dockerfile
@@ -1,0 +1,7 @@
+FROM raintank/kafka
+
+RUN apt-get update && apt-get install -y netcat
+
+ADD kafkaready.sh /usr/bin/kafkaready.sh
+EXPOSE 10101
+CMD ["kafkaready.sh"]

--- a/docker/kafkaready/kafkaready.sh
+++ b/docker/kafkaready/kafkaready.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+zk=${ZOOKEEPER:-localhost:2181}
+topic=${TOPIC:-mdm}
+parts=${PARTS:-16}
+maxAttempt=${MAX_ATTEMPTS:-40}
+
+attempt=0
+found=0
+
+function log {
+	echo "$(date '+%F %T') $@"
+}
+
+while true; do
+	attempt=$((attempt+1))
+	echo
+	log "###  waiting for topic $topic with $parts parts @ $zk.. attempt $attempt/$maxAttempt"
+	echo
+	out=$(/opt/kafka_2.11-0.10.0.1/bin/kafka-topics.sh --zookeeper $zk --topic $topic --describe 2>&1)
+	log "description of current topics matching mdm:"
+	log "$out"
+	if grep -q "PartitionCount:$parts" <<< "$out"; then
+		log "YES !!"
+		found=1
+		break
+	fi
+	log "nope...."
+	if [ $attempt -eq $maxAttempt ]; then
+		break
+	fi
+	sleep 1
+done
+
+if [ $found -eq 0 ]; then
+	log "FATAL: timed out waiting for topic $topic with $parts parts" >&2
+	exit 2
+fi
+
+nc -l -p 10101

--- a/docker/metrictank/metrictank.ini
+++ b/docker/metrictank/metrictank.ini
@@ -60,7 +60,7 @@ cassandra-consistency = one
 # tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
 cassandra-host-selection-policy = tokenaware,hostpool-epsilon-greedy
 # cassandra timeout in milliseconds
-cassandra-timeout = 1000
+cassandra-timeout = 4000
 # max number of concurrent reads to cassandra
 cassandra-read-concurrency = 500
 # max number of concurrent writes to cassandra

--- a/measure.sh
+++ b/measure.sh
@@ -20,6 +20,14 @@ COLUMNS=512 top -b -c | grep -v sed | sed -u -n \
   | awk '{print $6,$7,$11;fflush();}' \
   | while read mem cpu process; do
     ts=$(date +%s)
+    if [ "$ts" != "$prevTs" ]; then
+      # a bit hacky.. since we receive a stream of process measurements, where multiple graphite instances that need sequential numbering
+      # are intermingled with updates for the next time interval, we need a way to figure out when to bump the number vs resetting it.
+      # checking the timestamps of our parse loop is not rock solid but should be good enough
+      graphite_api_i=0
+      collector_i=0
+      mt_i=0
+    fi
     if [[ $mem =~ g$ ]]; then
 	    mem=$(bc -l <<< "${mem:0:-1} * 1024 * 1024 * 1024")
     elif [[ $mem =~ m$ ]]; then
@@ -36,10 +44,13 @@ COLUMNS=512 top -b -c | grep -v sed | sed -u -n \
       collector_i=$((collector_i + 1))
       echo "measure.${process}.${collector_i}.cpu $cpu $ts"
       echo "measure.${process}.${collector_i}.rss $mem $ts"
+    elif [ "$process" == "metrictank" ]; then
+      mt_i=$((mt_i + 1))
+      echo "measure.${process}.${mt_i}.cpu $cpu $ts"
+      echo "measure.${process}.${mt_i}.rss $mem $ts"
     else
-      graphite_api_i=0
-      collector_i=0
       echo "measure.${process}.cpu $cpu $ts"
       echo "measure.${process}.rss $mem $ts"
     fi
+    prevTs=$ts
 done | nc -c localhost 2003

--- a/screens/_metrictank
+++ b/screens/_metrictank
@@ -1,1 +1,8 @@
-docker logs -f raintank_metrictank_1 &> logs/metrictank.log
+docker logs -f raintank_metrictank0_1 &> logs/metrictank0.log &
+docker logs -f raintank_metrictank1_1 &> logs/metrictank1.log &
+docker logs -f raintank_metrictank2_1 &> logs/metrictank2.log &
+docker logs -f raintank_metrictank3_1 &> logs/metrictank3.log &
+docker logs -f raintank_metrictank4_1 &> logs/metrictank4.log &
+docker logs -f raintank_metrictank5_1 &> logs/metrictank5.log &
+docker logs -f raintank_metrictank6_1 &> logs/metrictank6.log &
+docker logs -f raintank_metrictank7_1 &> logs/metrictank7.log &

--- a/screens/benchmark
+++ b/screens/benchmark
@@ -27,3 +27,4 @@
 #inspect-es --es-addr elasticsearch:9200 -format vegeta-mt | sed 's#localhost:6063#metrictank:6063#' | vegeta attack -rate 100 -duration=99h | vegeta report
 
 #/scripts/cassandra-artificial-timeouts.sh
+/scripts/cluster-workload-gentle.sh


### PR DESCRIPTION
for https://github.com/raintank/metrictank/pull/320

doesn't work very well yet.  still getting some kafka and cassandra errors.

like 

```
2016/09/15 16:31:27 [cassandra.go:106 Init()] [E] cassandra-idx failed to initialize cassandra table. gocql: no response received from cassandra within timeout period

```

and

```
Sarama] 2016/09/15 16:31:29 client/metadata found some partitions to be leaderless
[Sarama] 2016/09/15 16:31:29 client/metadata retrying after 250ms... (3 attempts remaining)
[Sarama] 2016/09/15 16:31:29 client/metadata found some partitions to be leaderless
[Sarama] 2016/09/15 16:31:29 client/metadata retrying after 250ms... (3 attempts remaining)
[Sarama] 2016/09/15 16:31:29 client/metadata fetching metadata for [mdm] from broker kafka:9092

```

and also some metrictank kafka-mdm errors about partitions not existing (yet?)

to be continued...
